### PR TITLE
Allow ability to specify full Ga within a <additionalProductizedArtifactId/>

### DIFF
--- a/camel-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/maven/prod/CamelProdExcludesMojo.java
+++ b/camel-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/maven/prod/CamelProdExcludesMojo.java
@@ -262,7 +262,8 @@ public class CamelProdExcludesMojo extends AbstractMojo {
         }
         /* Add the additional ones */
         additionalProductizedArtifactIds.stream()
-                .map(artifactId -> new Ga("org.apache.camel", artifactId))
+                .map(artifactId -> (artifactId.contains(":") ? Ga.of(artifactId)
+                    : new Ga("org.apache.camel", artifactId)))
                 .forEach(includes::add);
         /*
          * Let's edit the pom.xml files out of the real source tree if we are just checking or pom editing is not

--- a/camel-spring-boot-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/spring/boot/maven/prod/CamelSpringBootProdExcludesMojo.java
+++ b/camel-spring-boot-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/spring/boot/maven/prod/CamelSpringBootProdExcludesMojo.java
@@ -258,7 +258,8 @@ public class CamelSpringBootProdExcludesMojo extends AbstractMojo {
         }
         /* Add the additional ones */
         additionalProductizedArtifactIds.stream()
-                .map(artifactId -> new Ga("org.apache.camel.springboot", artifactId))
+                .map(artifactId -> (artifactId.contains(":") ? Ga.of(artifactId)
+                        : new Ga("org.apache.camel.springboot", artifactId)))
                 .forEach(includes::add);
         /*
          * Let's edit the pom.xml files out of the real source tree if we are just checking or pom editing is not


### PR DESCRIPTION
camel-spring-boot needs to enable org.apache.camel.archetypes:camel-archetype-spring-boot which does not match the org.apache.camel.springboot groupId.   Allow the ability to specify a full Ga within <additionalProductizedArtifactId/>