### PR TITLE
Add dev support metadata option

### DIFF
--- a/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/ProdExcludesMojo.java
+++ b/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/ProdExcludesMojo.java
@@ -204,10 +204,11 @@ public class ProdExcludesMojo extends AbstractMojo {
     }
 
     enum ModeSupportStatus {
-        community, techPreview, supported;
+        community, techPreview, supported, devSupport;
 
         public boolean hasProductDocumentationPage() {
             switch (this) {
+            case devSupport:
             case techPreview:
             case supported:
                 return true;


### PR DESCRIPTION
Maybe we should eventually try to externalize the `ModeSupportStatus` bits? It'd avoid the need to release the plugin if we wanted to change it.