### PR TITLE
Set camel test-infra dependencies to ${camel-community.version} explicitly

### DIFF
--- a/camel-spring-boot-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/spring/boot/maven/prod/CamelSpringBootProdExcludesMojo.java
+++ b/camel-spring-boot-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/spring/boot/maven/prod/CamelSpringBootProdExcludesMojo.java
@@ -367,6 +367,21 @@ public class CamelSpringBootProdExcludesMojo extends AbstractMojo {
                                         dep.getVersion().getRawExpression())
                                         .ifPresent(transformations::add);
                             });
+
+                    /* We do not productize camel test-infra - we need to set these to ${camel-community.version} */
+                    profile.getDependencies().stream()
+                            .filter(dep -> "org.apache.camel".equals(dep.getGroupId().asConstant())
+                                    && "test-jar".equals(dep.getType())
+                                    && "test".equals(dep.getScope())
+                                    && dep.getArtifactId().asConstant().contains("test-infra")
+                                    && profile != null)
+                            .forEach(dep -> {
+                                final Ga ga = new Ga(dep.getGroupId().asConstant(), dep.getArtifactId().asConstant());
+                                final VersionStyle vs = versionStylesByPath.get(module.getPomPath());
+
+                                transformations.add(Transformation.setDependencyVersion(profile.getId(),
+                                        "${camel.community-version}", Collections.singletonList(ga)));
+                            });
                 }
 
                 if (!profile.getDependencyManagement().isEmpty()) {


### PR DESCRIPTION
When testing out the cq-camel-spring-boot plugin on the camel-spring-boot 4.x tags, the test-infra dependencies are not being set to camel-community.version.     I am not sure whether the test scope classifier or test-jar type are why - but we need to set these explicitly so they don't need to be changed manually every plugin run.