### PR TITLE
Remove camel's root pom.xml from camel-buildtools version changes

### DIFF
--- a/camel-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/maven/prod/CamelProdExcludesMojo.java
+++ b/camel-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/maven/prod/CamelProdExcludesMojo.java
@@ -422,7 +422,8 @@ public class CamelProdExcludesMojo extends AbstractMojo {
                         .transform(transformations);
             }
         });
-        Stream.of("pom.xml", "parent/pom.xml").forEach(relPath -> {
+
+        Stream.of("parent/pom.xml").forEach(relPath -> {
             new PomTransformer(workRoot.resolve(relPath), charset, simpleElementWhitespace)
                     .transform(Transformation.setTextValue("/" +
                             PomTunerUtils.anyNs("dependency", "version") + "[.." + PomTunerUtils.anyNs("artifactId")


### PR DESCRIPTION
Remove camel's root pom.xml from the list of files where the camel-buildtools needs to be set - in camel 4.0.0-RC2, camel-buildtools has been removed from camel's root pom.xml