### PR TITLE
Camel 4 camel-package-manager moved to plexus-utils 4 - API changes

### DIFF
--- a/camel-prod-maven-plugin/pom.xml
+++ b/camel-prod-maven-plugin/pom.xml
@@ -75,6 +75,19 @@
         </dependency>
 
         <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-build-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.l2x6.pom-tuner</groupId>
             <artifactId>pom-tuner</artifactId>
         </dependency>

--- a/camel-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/maven/prod/CamelProdExcludesMojo.java
+++ b/camel-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/maven/prod/CamelProdExcludesMojo.java
@@ -54,6 +54,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.build.DefaultBuildContext;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -70,7 +71,6 @@ import org.l2x6.pom.tuner.model.Dependency;
 import org.l2x6.pom.tuner.model.Ga;
 import org.l2x6.pom.tuner.model.Module;
 import org.l2x6.pom.tuner.model.Profile;
-import org.sonatype.plexus.build.incremental.DefaultBuildContext;
 import org.w3c.dom.Document;
 
 /**
@@ -505,7 +505,7 @@ public class CamelProdExcludesMojo extends AbstractMojo {
                         mojo.setLog(getLog());
                         mojo.setPluginContext(getPluginContext());
                         mojo.execute(project, projectHelper,
-                                new org.codehaus.plexus.build.DefaultBuildContext(new DefaultBuildContext()));
+                                new DefaultBuildContext(new org.sonatype.plexus.build.incremental.DefaultBuildContext()));
 
                     } catch (Exception e) {
                         throw new RuntimeException("Could not excute ComponentDslMojo in " + moduleBaseDir, e);

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -60,6 +60,14 @@
 
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-xml</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.freemarker</groupId>

--- a/filtered-external-enforcer-rules/pom.xml
+++ b/filtered-external-enforcer-rules/pom.xml
@@ -43,6 +43,15 @@
         </dependency>
 
         <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-xml</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/maven-plugin/src/main/java/org/l2x6/cq/maven/CreateTestMojo.java
+++ b/maven-plugin/src/main/java/org/l2x6/cq/maven/CreateTestMojo.java
@@ -174,7 +174,7 @@ public class CreateTestMojo extends AbstractExtensionListMojo {
      * <li>{@code TestResource.java}</li>
      * </ul>
      * Note that you do not need to provide all of them. Files not available in your custom {@link #templatesUriBase}
-     * will be looked up in the default URI base {@value #DEFAULT_TEMPLATES_URI_BASE}. The default templates are
+     * will be looked up in the default URI base (CqUtils.DEFAULT_TEMPLATES_URI_BASE). The default templates are
      * maintained <a href=
      * "https://github.com/quarkusio/quarkus/tree/main/devtools/maven/src/main/resources/create-extension-templates">here</a>.
      *

--- a/maven-plugin/src/test/java/org/l2x6/cq/maven/CreateExtensionMojoTest.java
+++ b/maven-plugin/src/test/java/org/l2x6/cq/maven/CreateExtensionMojoTest.java
@@ -30,7 +30,6 @@ import org.apache.maven.model.PluginManagement;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.l2x6.cq.common.CqCommonUtils;
 import org.l2x6.cq.test.utils.TestUtils;
@@ -38,9 +37,7 @@ import org.l2x6.pom.tuner.PomTransformer.SimpleElementWhitespace;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Disabled("Dozer component removed in Camel 4, Test throws errors because it is no longer in the Camel 4 Catalog")
 public class CreateExtensionMojoTest {
-
     private static CreateExtensionMojo initMojo(final Path projectDir) throws IOException {
         final CreateExtensionMojo mojo = new CreateExtensionMojo();
         mojo.project = new MavenProject();

--- a/maven-plugin/src/test/java/org/l2x6/cq/maven/CreateExtensionMojoTest.java
+++ b/maven-plugin/src/test/java/org/l2x6/cq/maven/CreateExtensionMojoTest.java
@@ -30,6 +30,7 @@ import org.apache.maven.model.PluginManagement;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.l2x6.cq.common.CqCommonUtils;
 import org.l2x6.cq.test.utils.TestUtils;
@@ -37,6 +38,7 @@ import org.l2x6.pom.tuner.PomTransformer.SimpleElementWhitespace;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Disabled("Dozer component removed in Camel 4, Test throws errors because it is no longer in the Camel 4 Catalog")
 public class CreateExtensionMojoTest {
 
     private static CreateExtensionMojo initMojo(final Path projectDir) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
         <freemarker.version>2.3.32</freemarker.version>
         <assertj.version>3.24.2</assertj.version>
 
+        <plexus-build-api-version>1.2.0</plexus-build-api-version>
+        <plexus-container-default-version>2.1.1</plexus-container-default-version>
+        <plexus-utils-version>4.0.0</plexus-utils-version>
+        <plexus-xml-version>4.0.2</plexus-xml-version>
+
         <!-- Plugins and their dependencies -->
         <buildnumber-maven-plugin.version>3.2.0</buildnumber-maven-plugin.version>
         <editorconfig-maven-plugin.version>0.1.3</editorconfig-maven-plugin.version>
@@ -293,6 +298,27 @@
                 <groupId>org.apache.maven.shared</groupId>
                 <artifactId>maven-shared-utils</artifactId>
                 <version>${maven.shared.utils}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-container-default</artifactId>
+                <version>${plexus-container-default-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>${plexus-utils-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-xml</artifactId>
+                <version>${plexus-xml-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-build-api</artifactId>
+                <version>${plexus-build-api-version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Changes to enable Camel 4 camel-package-maven-plugin (plexus-util upgrade occurred on Camel 4, requires API changes)