### PR TITLE
The m-shared-utils dependency is required and not provided

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-shared-utils</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
@ppalaga I can't build camel-quarkus without adding the maven-shared-utils dependency to this plugin (I do that in the camel-quarkuss build, but it should not be needed)