### PR TITLE
Update maven-compiler-plugin source & release version to 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,8 +127,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- maven-compiler-plugin -->
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
 
         <!-- license-maven-plugin -->


### PR DESCRIPTION
I think this should be safe. AFAIK all of the projects using the different plugins & mojos have a minimum JDK version requirement of 17.