### PR TITLE
Add prod-maven-plugin mojo to sync example projects from upstream

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,6 +31,7 @@ A collection of maven plugins related to https://github.com/apache/camel-quarkus
 
 * camel-prod-excludes-check : Check whether the modules that should not be productized are properly unlinked from Camel source tree based on product/src/main/resources/required-productized-camel-artifacts.txt.
 * camel-prod-excludes : Unlink modules that should not be productized from Camel source tree based on product/src/main/resources/required-productized-camel-artifacts.txt.
+* sync-examples-from-upstream: Synchronizes the jboss-fuse/camel-quarkus-examples product fork with a community camel-quarkus-examples branch
 
 === Usage
 
@@ -62,6 +63,18 @@ mvn org.l2x6.cq:cq-camel-prod-maven-plugin:check-excludes
 ....
 
 From CAMEL_HOME, camel-prod-excludes is used to comment out modules that should not be productized.
+
+*sync-examples-from-upstream*:
+
+The minimal command to sync example projects from upstream is:
+
+....
+mvn org.l2x6.cq:cq-prod-maven-plugin:sync-examples-from-upstream -Dcq.quarkus.platform.version=<the platform version to use> -DsyncToDir=/path/to/example/projects
+....
+
+You can omit the `syncToDir` option if you change into the directory where you want to sync example projects to.
+
+Use `mvn help:describe` to see the full set of parameters.
 
 *cq-camel-prod-maven-plugin* configured in the camel pom.xml :
 
@@ -99,7 +112,6 @@ mvn org.l2x6.cq:cq-camel-prod-maven-plugin:camel-prod-excludes -N
 ....
 
 === Examples
-
 
 == *camel-spring-bot-prod-maven-plugin* : A Maven plugin to perform various tasks related to productized Camel Spring Boot
 

--- a/alias-fastinstall-quickly-extension/pom.xml
+++ b/alias-fastinstall-quickly-extension/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.l2x6.cq</groupId>
         <artifactId>cq</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cq-alias-fastinstall-quickly-extension</artifactId>

--- a/camel-prod-maven-plugin/pom.xml
+++ b/camel-prod-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.l2x6.cq</groupId>
         <artifactId>cq</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cq-camel-prod-maven-plugin</artifactId>

--- a/camel-spring-boot-prod-maven-plugin/pom.xml
+++ b/camel-spring-boot-prod-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.l2x6.cq</groupId>
         <artifactId>cq</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cq-camel-spring-boot-prod-maven-plugin</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.l2x6.cq</groupId>
         <artifactId>cq</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cq-common</artifactId>

--- a/filtered-external-enforcer-rules/pom.xml
+++ b/filtered-external-enforcer-rules/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.l2x6.cq</groupId>
         <artifactId>cq</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cq-filtered-external-enforcer-rules</artifactId>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.l2x6.cq</groupId>
         <artifactId>cq</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cq-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.l2x6.cq</groupId>
     <artifactId>cq</artifactId>
-    <version>4.10.3-SNAPSHOT</version>
+    <version>4.11.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>CQ</name>
@@ -215,17 +215,17 @@
             <dependency>
                 <groupId>org.l2x6.cq</groupId>
                 <artifactId>cq-common</artifactId>
-                <version>4.10.3-SNAPSHOT</version>
+                <version>4.11.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.l2x6.cq</groupId>
                 <artifactId>cq-test-utils</artifactId>
-                <version>4.10.3-SNAPSHOT</version>
+                <version>4.11.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.l2x6.cq</groupId>
                 <artifactId>cq-maven-plugin</artifactId>
-                <version>4.10.3-SNAPSHOT</version>
+                <version>4.11.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/prod-maven-plugin/pom.xml
+++ b/prod-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.l2x6.cq</groupId>
         <artifactId>cq</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cq-prod-maven-plugin</artifactId>

--- a/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/SyncExamplesFromUpstreamMojo.java
+++ b/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/SyncExamplesFromUpstreamMojo.java
@@ -1,0 +1,790 @@
+/*
+ * Copyright (c) 2020 CQ Maven Plugin
+ * project contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.l2x6.cq.maven.prod;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.RepositoryUtils;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Profile;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.eclipse.aether.util.filter.DependencyFilterUtils;
+import org.l2x6.cq.common.CqCommonUtils;
+import org.l2x6.pom.tuner.PomTransformer;
+import org.l2x6.pom.tuner.PomTransformer.ContainerElement;
+import org.l2x6.pom.tuner.PomTransformer.TransformationContext;
+import org.w3c.dom.Document;
+
+/**
+ * Sync Camel Quarkus Example projects from an upstream GitHub branch to a local destination directory.
+ *
+ * @since 4.11.0
+ */
+@Mojo(name = "sync-examples-from-upstream", threadSafe = true, requiresProject = false)
+public class SyncExamplesFromUpstreamMojo extends AbstractMojo {
+    private static final String EXPRESSION_REGEX = "\\$\\{([^}]+)}";
+    private static final Pattern EXPRESSION = Pattern.compile(EXPRESSION_REGEX);
+    private static final String GITHUB_BASE_URL = "https://github.com/apache/camel-quarkus-examples/archive/refs/heads/%s.zip";
+    private static final String MRRC_GA_URL = "https://maven.repository.redhat.com/ga/";
+    private static final String MRRC_EARLYACCESS_URL = "https://maven.repository.redhat.com/earlyaccess/all/";
+    private static final Set<String> ALLOWED_UNPRODUCTIZED_DEPENDENCIES = Set.of(
+            "com.ibm.mq:com.ibm.mq.jakarta.client",
+            "io.quarkus:quarkus-jdbc-h2",
+            "io.quarkus:quarkus-flyway",
+            "io.strimzi:kafka-oauth-client",
+            "org.flywaydb:flyway-mysql");
+
+    @Component
+    RepositorySystem repositorySystem;
+
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    List<RemoteRepository> repositories;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
+    private RepositorySystemSession session;
+
+    /**
+     * The groupId of the Quarkus Platform Quarkus BOM
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.quarkus.platform.group-id", defaultValue = "com.redhat.quarkus.platform")
+    String quarkusPlatformGroupId;
+
+    /**
+     * The artifactId of the Quarkus Platform Quarkus BOM
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.quarkus.platform.artifact-id", defaultValue = "quarkus-bom")
+    String quarkusPlatformArtifactId;
+
+    /**
+     * The version of the Quarkus Platform Quarkus BOM
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.quarkus.platform.version", required = true)
+    String quarkusPlatformVersion;
+
+    /**
+     * The Maven groupId of the Quarkus Platform Camel Quarkus BOM
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.camel-quarkus.platform.group-id")
+    String camelQuarkusPlatformGroupId = "${quarkus.platform.group-id}";
+
+    /**
+     * The Maven artifactId of the Quarkus Platform Camel Quarkus BOM
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.camel-quarkus.platform.artifact-id", defaultValue = "quarkus-camel-bom")
+    String camelQuarkusPlatformArtifactId;
+
+    /**
+     * The Maven version of the Quarkus Platform Camel Quarkus BOM
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.camel-quarkus.platform.version")
+    String camelQuarkusPlatformVersion = "${quarkus.platform.version}";
+
+    /**
+     * Whether to ignore sync criteria (E.g. productized dependencies) and force syncing of projects
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.force", defaultValue = "false")
+    boolean isForce;
+
+    /**
+     * Whether to only perform dependency analysis on projects and not sync them
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.analyzeOnly", defaultValue = "false")
+    boolean isAnalyzeOnly;
+
+    /**
+     * Whether to use a cached download of the GitHub target branch zip archive
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.useCache", defaultValue = "true")
+    boolean isUseCache;
+
+    /**
+     * The path to the directory where projects should be synced from. When set, this overrides the default behavior where
+     * the sources to sync from are downloaded from GitHub
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.syncFromDir")
+    File syncFromDir;
+
+    /**
+     * The path to the directory where projects should be synced to
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.syncToDir", defaultValue = "${user.dir}")
+    File syncToDir;
+
+    /**
+     * The path to the temporary directory where this mojo performs its work
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.tmpDir", defaultValue = "${java.io.tmpdir}")
+    File tmpDir;
+
+    /**
+     * Comma separated list of directory names for example projects to include. When not specified, all discovered projects
+     * are included
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.projectIncludes")
+    Set<String> projectIncludes = new HashSet<>();
+
+    /**
+     * Comma separated list of directory names for example projects to exclude
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.projectExcludes")
+    Set<String> projectExcludes = new HashSet<>();
+
+    /**
+     * Comma separated list of groupId:artifactId keys for project dependencies that should be ignored when considering
+     * whether they are productized or not
+     *
+     * @since 4.11.0
+     */
+    @Parameter(property = "cq.ignoredDependencies")
+    Set<String> ignoredDependencies;
+
+    List<SourceTransformer> preSyncTransformers = new ArrayList<>();
+    List<SourceTransformer> postSyncTransformers = new ArrayList<>();
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        // Configure a common set of dependencies to always be ignored
+        ignoredDependencies.addAll(ALLOWED_UNPRODUCTIZED_DEPENDENCIES);
+
+        // Configure source transformations
+        setUpSourceTransformations();
+
+        try {
+            if (syncFromDir == null) {
+                // Download the community example projects as a GitHub source archive for the target branch
+                downloadGitHubBranchArchive();
+                // Unzip archive contents
+                extractZipFile();
+            }
+
+            // Analyze example project dependencies and sync content
+            Map<String, Set<GAV>> dependencies = analyzeDependencies();
+            syncProjects(dependencies);
+        } catch (Exception e) {
+            throw new MojoExecutionException(e);
+        }
+    }
+
+    void downloadGitHubBranchArchive() throws MojoExecutionException {
+        URL downloadUrl = getGitHubBranchArchiveURL();
+        Path downloadDestination = getArchivePath();
+        if (isUseCache && Files.exists(downloadDestination)) {
+            getLog().info("Using cached download of %s".formatted(downloadUrl));
+            return;
+        }
+
+        getLog().info("Downloading %s to %s".formatted(downloadUrl, downloadDestination));
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) downloadUrl.openConnection();
+            connection.setRequestMethod("GET");
+            connection.connect();
+
+            if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                throw new MojoExecutionException("Failed to download upstream branch sources from: " + downloadUrl);
+            }
+
+            try (InputStream inputStream = new BufferedInputStream(connection.getInputStream());
+                    FileOutputStream fileOutputStream = new FileOutputStream(downloadDestination.toFile())) {
+
+                byte[] buffer = new byte[1024];
+                int bytesRead;
+                while ((bytesRead = inputStream.read(buffer)) != -1) {
+                    fileOutputStream.write(buffer, 0, bytesRead);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    void extractZipFile() throws Exception {
+        Path zipFile = getArchivePath();
+        Path parent = zipFile.getParent();
+        Path extractedDir = parent.resolve(zipFile.getFileName().toString().replace(".zip", ""));
+
+        if (Files.exists(extractedDir)) {
+            FileUtils.deleteDirectory(extractedDir.toFile());
+        }
+
+        getLog().info("Extracting " + zipFile);
+        try (ZipInputStream zipInputStream = new ZipInputStream(new BufferedInputStream(Files.newInputStream(zipFile)))) {
+            ZipEntry entry;
+            while ((entry = zipInputStream.getNextEntry()) != null) {
+                String fileName = entry.getName();
+                Path filePath = parent.resolve(fileName);
+                if (entry.isDirectory()) {
+                    Files.createDirectories(filePath);
+                } else {
+                    Files.createDirectories(filePath.getParent());
+                    byte[] buffer = new byte[1024];
+                    int bytesRead;
+                    try (FileOutputStream fos = new FileOutputStream(filePath.toFile())) {
+                        while ((bytesRead = zipInputStream.read(buffer)) != -1) {
+                            fos.write(buffer, 0, bytesRead);
+                        }
+                    }
+                }
+                zipInputStream.closeEntry();
+            }
+        }
+    }
+
+    Map<String, Set<GAV>> analyzeDependencies() throws Exception {
+        Path downloadDestination = getExtractedArchivePath();
+        Map<String, Set<GAV>> projectDependencies = new TreeMap<>();
+
+        getLog().info("⚙️ Analyzing example projects. This may take some time if dependencies are not yet cached...");
+        Files.walkFileTree(downloadDestination, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                // Perform any custom pre-processing on specific files
+                preSyncTransformers.stream()
+                        .filter(sourceTransformer -> sourceTransformer.canApply(file))
+                        .forEach(sourceTransformer -> sourceTransformer.apply(file));
+
+                if (attrs.isRegularFile() && file.getFileName().toString().equals("pom.xml")) {
+                    Path exampleProjectDirectory = file.getParent();
+                    String exampleProjectName = exampleProjectDirectory.getFileName().toString();
+
+                    if ((!projectExcludes.contains(exampleProjectName))
+                            && (projectIncludes.isEmpty() || projectIncludes.contains(exampleProjectName))) {
+                        try {
+                            getLog().info("✨ Analyzing example project " + exampleProjectName);
+                            Set<GAV> dependencies = getDependencies(file);
+
+                            // Handle multi-module projects
+                            Path parentPomXml = exampleProjectDirectory.getParent().resolve("pom.xml");
+                            if (Files.exists(parentPomXml)) {
+                                exampleProjectName = parentPomXml.getParent().getFileName() + "/" + exampleProjectName;
+                            }
+
+                            projectDependencies.put(exampleProjectName, dependencies);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    } else {
+                        getLog().info("❌ Skipping excluded project %s".formatted(exampleProjectName));
+                    }
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        return projectDependencies;
+    }
+
+    void syncProjects(Map<String, Set<GAV>> projectDependencies) throws Exception {
+        if (isAnalyzeOnly) {
+            getLog().info("⚠️ The analyzeOnly option is enabled. Syncing projects will be disabled");
+        }
+
+        Path downloadDestination = getExtractedArchivePath();
+        for (Map.Entry<String, Set<GAV>> entry : projectDependencies.entrySet()) {
+            Set<GAV> unproductizedDeps = entry.getValue()
+                    .stream()
+                    .filter(GAV::isUnProductized)
+                    .collect(Collectors.toUnmodifiableSet());
+            if (unproductizedDeps.isEmpty() || isForce) {
+                String message = "all runtime dependencies are productized";
+                if (isForce) {
+                    message = "the force option is true";
+                }
+
+                getLog().info("✅ Syncing project %s as %s".formatted(entry.getKey(), message));
+                entry.getValue().forEach(gav -> getLog().info("    " + gav.toString()));
+
+                if (isAnalyzeOnly) {
+                    continue;
+                }
+
+                Path projectToSync = downloadDestination.resolve(entry.getKey());
+                Files.walk(projectToSync).forEach(source -> {
+                    try {
+                        Path destination = syncToDir.toPath().resolve(downloadDestination.relativize(source));
+                        if (Files.isDirectory(destination) && Files.exists(destination)) {
+                            return;
+                        }
+
+                        if (!FileUtils.contentEquals(source.toFile(), destination.toFile()) || isForce) {
+                            getLog().debug("Syncing file %s to %s".formatted(source, destination));
+                            Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
+                        } else {
+                            getLog().debug("Not syncing file %s to %s. Content already matches".formatted(source, destination));
+                        }
+
+                        // Perform any custom post-processing on specific files
+                        postSyncTransformers.stream()
+                                .filter(sourceTransformer -> sourceTransformer.canApply(destination))
+                                .forEach(sourceTransformer -> sourceTransformer.apply(destination));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            } else {
+                getLog().info("❌ Skipping sync of project %s as not all runtime dependencies are productized"
+                        .formatted(entry.getKey()));
+                unproductizedDeps.forEach(gav -> getLog().info("    " + gav.toString()));
+            }
+        }
+    }
+
+    Set<GAV> getDependencies(Path pomXml) throws Exception {
+        Model model = CqCommonUtils.readPom(pomXml, StandardCharsets.UTF_8);
+
+        if (model.getGroupId() != null && !model.getGroupId().equals("org.apache.camel.quarkus.examples")) {
+            getLog().warn("Skipping sync of %s it does not appear to be a camel-quarkus example project"
+                    .formatted(pomXml.getParent().getFileName()));
+        }
+
+        if (model.getDependencies() == null || model.getDependencies().isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        Properties properties = new Properties();
+        properties.putAll(model.getProperties());
+
+        List<org.apache.maven.model.Dependency> managedDependencies = new ArrayList<>();
+        List<org.apache.maven.model.Dependency> dependencies = new ArrayList<>();
+
+        model.getDependencyManagement()
+                .getDependencies()
+                .stream()
+                .filter(dependency -> dependency.getScope() == null || !dependency.getScope().equals("test"))
+                .forEach(managedDependencies::add);
+
+        model.getDependencies()
+                .stream()
+                .filter(dependency -> dependency.getScope() == null || !dependency.getScope().equals("test"))
+                .forEach(dependencies::add);
+
+        for (Profile profile : model.getProfiles()) {
+            if (profile.getDependencyManagement() != null) {
+                profile.getDependencyManagement()
+                        .getDependencies()
+                        .stream()
+                        .filter(dependency -> dependency.getScope() == null || !dependency.getScope().equals("test"))
+                        .forEach(managedDependencies::add);
+            }
+            if (profile.getDependencies() != null) {
+                profile.getDependencies()
+                        .stream()
+                        .filter(dependency -> dependency.getScope() == null || !dependency.getScope().equals("test"))
+                        .forEach(dependencies::add);
+            }
+            if (profile.getProperties() != null) {
+                properties.putAll(profile.getProperties());
+            }
+        }
+
+        CollectRequest collectRequest = new CollectRequest();
+        collectRequest.setRepositories(repositories);
+
+        managedDependencies.forEach(dep -> {
+            String groupId = resolveGavElement(dep.getGroupId(), properties);
+            String artifactId = resolveGavElement(dep.getArtifactId(), properties);
+            String version = resolveGavElement(dep.getVersion(), properties);
+
+            Artifact artifact = new DefaultArtifact(
+                    groupId + ":" + artifactId + ":pom:" + version);
+            ArtifactDescriptorRequest descriptorRequest = new ArtifactDescriptorRequest();
+            descriptorRequest.setArtifact(artifact);
+            descriptorRequest.setRepositories(repositories);
+            try {
+                ArtifactDescriptorResult descriptorResult = repositorySystem.readArtifactDescriptor(session,
+                        descriptorRequest);
+                descriptorResult.getManagedDependencies().forEach(collectRequest::addManagedDependency);
+                collectRequest.addManagedDependency(RepositoryUtils.toDependency(dep, session.getArtifactTypeRegistry()));
+            } catch (ArtifactDescriptorException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        dependencies.forEach(dep -> {
+            Optional<Dependency> match = collectRequest.getManagedDependencies()
+                    .stream().filter(dependency -> {
+                        Artifact artifact = dependency.getArtifact();
+                        return artifact.getGroupId().equals(dep.getGroupId())
+                                && artifact.getArtifactId().equals(dep.getArtifactId());
+                    })
+                    .findFirst();
+
+            if (match.isPresent()) {
+                collectRequest.addDependency(match.get());
+            } else {
+                dep.setGroupId(resolveGavElement(dep.getGroupId(), properties));
+                dep.setArtifactId(resolveGavElement(dep.getArtifactId(), properties));
+                if (dep.getVersion() != null) {
+                    String version = resolveGavElement(dep.getVersion(), properties);
+                    dep.setVersion(version);
+                    collectRequest.addDependency(RepositoryUtils.toDependency(dep, session.getArtifactTypeRegistry()));
+                } else {
+                    getLog().info(
+                            "⚠️ Unable to find a valid version for %s:%s in project %s".formatted(dep.getGroupId(),
+                                    dep.getArtifactId(),
+                                    model.getArtifactId()));
+                }
+            }
+        });
+
+        DependencyFilter classpathFilter = DependencyFilterUtils.classpathFilter(JavaScopes.COMPILE);
+        DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, classpathFilter);
+        DependencyResult result = repositorySystem.resolveDependencies(session, dependencyRequest);
+        List<DependencyNode> children = result.getRoot().getChildren();
+        Set<GAV> projectDependencies = new HashSet<>();
+        for (DependencyNode node : children) {
+            Artifact artifact = node.getArtifact();
+            boolean isIgnored = ignoredDependencies.contains(artifact.getGroupId() + ":" + artifact.getArtifactId());
+            projectDependencies.add(new GAV(artifact, isIgnored));
+        }
+        return projectDependencies;
+    }
+
+    String resolveGavElement(String value, Properties properties) {
+        if (value.contains("${")) {
+            Matcher matcher = EXPRESSION.matcher(value);
+            if (matcher.find()) {
+                return resolveGavElement(properties.getProperty(matcher.group(1)), properties);
+            }
+        }
+        return value;
+    }
+
+    void setUpSourceTransformations() {
+        setUpPreSyncSourceTransformations();
+        setUpPostSyncSourceTransformations();
+    }
+
+    /**
+     * Source transformations that should be applied before dependency analysis is run and before the example project is
+     * synced to its destination.
+     */
+    void setUpPreSyncSourceTransformations() {
+        // pom.xml transforms. Anything that might impact the result of dependency analysis should be done here.
+        preSyncTransformers.add(new SourceTransformer() {
+            @Override
+            public boolean canApply(Path source) {
+                return source.toFile().getName().equals("pom.xml");
+            }
+
+            @Override
+            public void apply(Path source) {
+                PomTransformer pomTransformer = new PomTransformer(source, StandardCharsets.UTF_8,
+                        PomTransformer.SimpleElementWhitespace.SPACE);
+
+                pomTransformer.transform(new PomTransformer.Transformation() {
+                    @Override
+                    public void perform(Document document, TransformationContext context) {
+                        ContainerElement project = context.getContainerElement("project").orElseThrow();
+
+                        // Update the example project version to a productized scheme
+                        project.addOrSetChildTextElement("version", getCamelQuarkusExamplesVersion());
+
+                        // Update BOM version properties
+                        ContainerElement properties = context.getOrAddContainerElement("properties");
+                        properties.addOrSetChildTextElement("quarkus.platform.group-id", quarkusPlatformGroupId);
+                        properties.addOrSetChildTextElement("quarkus.platform.artifact-id", quarkusPlatformArtifactId);
+                        properties.addOrSetChildTextElement("quarkus.platform.version", quarkusPlatformVersion);
+                        properties.addOrSetChildTextElement("camel-quarkus.platform.group-id", camelQuarkusPlatformGroupId);
+                        properties.addOrSetChildTextElement("camel-quarkus.platform.artifact-id",
+                                camelQuarkusPlatformArtifactId);
+                        properties.addOrSetChildTextElement("camel-quarkus.platform.version", camelQuarkusPlatformVersion);
+
+                        // Add MRRC repositories
+                        ContainerElement repositories = context.getOrAddContainerElements("repositories");
+                        addRepository(repositories, "redhat-ga-repository", MRRC_GA_URL, false);
+                        addRepository(repositories, "redhat-earlyaccess-repository", MRRC_EARLYACCESS_URL, false);
+
+                        ContainerElement pluginRepositories = context.getOrAddContainerElements("pluginRepositories");
+                        addRepository(pluginRepositories, "redhat-ga-repository", MRRC_GA_URL, true);
+                        addRepository(pluginRepositories, "redhat-earlyaccess-repository", MRRC_EARLYACCESS_URL, true);
+
+                        // Remove kubernetes profile
+                        context.getOrAddProfileParent("kubernetes").remove(true, true);
+
+                        // Remove explicit version for quarkus-artemis-jms since these dependencies are in the productized platform BOMs
+                        if (camelQuarkusPlatformArtifactId.equals("quarkus-camel-bom")) {
+                            context.getDependencies()
+                                    .stream()
+                                    .filter(dependency -> dependency.getArtifactId().equals("quarkus-artemis-jms"))
+                                    .findFirst()
+                                    .ifPresent(quarkusArtemis -> {
+                                        quarkusArtemis.getNode()
+                                                .getChildContainerElement("version")
+                                                .ifPresent(containerElement -> containerElement.remove(true, true));
+                                    });
+                        }
+                    }
+                });
+            }
+
+            private void addRepository(ContainerElement parent, String id, String url, boolean isPluginRepository) {
+                String tagName = isPluginRepository ? "pluginRepository" : "repository";
+                ContainerElement repository = parent.addChildContainerElement(tagName);
+                repository.addChildTextElement("id", id);
+                repository.addChildTextElement("url", url);
+                ContainerElement repositoryReleases = repository.getOrAddChildContainerElement("releases");
+                repositoryReleases.addChildTextElement("enabled", "true");
+                ContainerElement repositorySnapshots = repository.getOrAddChildContainerElement("snapshots");
+                repositorySnapshots.addChildTextElement("enabled", "false");
+            }
+        });
+    }
+
+    /**
+     * Source transformations to apply after the example project is synced to its destination.
+     */
+    void setUpPostSyncSourceTransformations() {
+        // Remove Kubernetes manifests
+        postSyncTransformers.add(new SourceTransformer() {
+            @Override
+            public boolean canApply(Path source) {
+                return source.getParent().getFileName().toString().equals("kubernetes")
+                        && source.getFileName().toString().equals("kubernetes.yml");
+            }
+
+            @Override
+            public void apply(Path source) {
+                try {
+                    Files.deleteIfExists(source);
+                } catch (IOException e) {
+                    getLog().error("Failed deleting Kubernetes manifest", e);
+                }
+            }
+        });
+
+        // README updates
+        postSyncTransformers.add(new SourceTransformer() {
+            static final String HEADING_REGEX = "(?s)Deploying to Kubernetes.*?(?=Deploying to OpenShift)";
+
+            @Override
+            public boolean canApply(Path source) {
+                return source.getFileName().toString().equals("README.adoc");
+            }
+
+            @Override
+            public void apply(Path source) {
+                try {
+                    String content = Files.readString(source);
+
+                    // Remove Kubernetes deployment instructions and leave OpenShift docs
+                    String updatedContent = content.replaceFirst(HEADING_REGEX, "");
+                    if (!content.equals(updatedContent)) {
+                        Files.writeString(source, updatedContent);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
+
+    String getCamelQuarkusExamplesVersion() {
+        return resolveCamelQuarkusPlatformVersion().substring(0, 3) + ".0-redhat-00001";
+    }
+
+    String getGitHubDownloadBaseUrl() {
+        return GITHUB_BASE_URL;
+    }
+
+    Path getArchivePath() {
+        return tmpDir.toPath().resolve("camel-quarkus-examples-%s.zip".formatted(getUpstreamBranchName()));
+    }
+
+    URL getGitHubBranchArchiveURL() {
+        String url = getGitHubDownloadBaseUrl().formatted(getUpstreamBranchName());
+        try {
+            return new URL(url);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    String getUpstreamBranchName() {
+        String[] versionParts = resolveCamelQuarkusPlatformVersion().split("\\.");
+        return "%s.%s.x".formatted(versionParts[0], versionParts[1]);
+    }
+
+    String resolveCamelQuarkusPlatformVersion() {
+        if (camelQuarkusPlatformVersion.equals("${quarkus.platform.version}")) {
+            return quarkusPlatformVersion;
+        }
+        return camelQuarkusPlatformVersion;
+    }
+
+    Path getExtractedArchivePath() {
+        if (syncFromDir != null) {
+            return syncFromDir.toPath();
+        }
+        return tmpDir.toPath().resolve("camel-quarkus-examples-%s".formatted(getUpstreamBranchName()));
+    }
+
+    static final class GAV {
+        private final Artifact artifact;
+        private final boolean ignored;
+
+        public GAV(Artifact artifact, boolean ignored) {
+            this.artifact = artifact;
+            this.ignored = ignored;
+        }
+
+        public String getGroupId() {
+            return artifact.getGroupId();
+        }
+
+        public String getArtifactId() {
+            return artifact.getArtifactId();
+        }
+
+        public String getVersion() {
+            return artifact.getVersion();
+        }
+
+        public boolean isUnProductized() {
+            return !ignored && !getVersion().contains(".redhat");
+        }
+
+        public boolean isIgnored() {
+            return ignored;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            GAV gav = (GAV) o;
+            return Objects.equals(artifact, gav.artifact);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(artifact);
+        }
+
+        @Override
+        public String toString() {
+            if (ignored) {
+                return "%s:%s:%s (unproductized but allowed)".formatted(getGroupId(), getArtifactId(), getVersion());
+            } else {
+                return "%s:%s:%s".formatted(getGroupId(), getArtifactId(), getVersion());
+            }
+        }
+    }
+
+    interface SourceTransformer {
+        /**
+         * Whether the transformer can run.
+         *
+         * @param  source The source file to be transformed
+         * @return        {@code true} if the source file can be transformed. {@code false} if transformations should not be
+         *                applied.
+         */
+        boolean canApply(Path source);
+
+        /**
+         * Applies transformations to the given file.
+         *
+         * @param source The path to the source file to transform
+         */
+        void apply(Path source);
+    }
+}

--- a/prod-maven-plugin/src/test/examples/community/bar/pom.xml
+++ b/prod-maven-plugin/src/test/examples/community/bar/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 CQ Maven Plugin
+    project contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.camel.quarkus</groupId>
+    <artifactId>camel-quarkus-bar</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>Camel Quarkus :: Examples :: Bar</name>
+    <description>Camel Quarkus Example :: Bar</description>
+
+    <properties>
+        <quarkus.platform.version>3.8.5</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>${camel-quarkus.platform.group-id}</groupId>
+                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
+                <version>${camel-quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-bean</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-log</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-zookeeper</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/prod-maven-plugin/src/test/examples/community/bar/src/main/java/org/acme/Bar.java
+++ b/prod-maven-plugin/src/test/examples/community/bar/src/main/java/org/acme/Bar.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 CQ Maven Plugin
+ * project contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.acme;
+
+public class Bar {
+}

--- a/prod-maven-plugin/src/test/examples/community/foo/README.adoc
+++ b/prod-maven-plugin/src/test/examples/community/foo/README.adoc
@@ -1,0 +1,21 @@
+= Foo example project
+
+Foo project used in unit testing
+
+==== Deploying to Kubernetes
+
+Some
+fictional
+content
+about
+deploying
+to Kubernetes
+
+==== Deploying to OpenShift
+
+Some
+fictional
+content
+about
+deploying
+to OpenShift

--- a/prod-maven-plugin/src/test/examples/community/foo/pom.xml
+++ b/prod-maven-plugin/src/test/examples/community/foo/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 CQ Maven Plugin
+    project contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.camel.quarkus</groupId>
+    <artifactId>camel-quarkus-foo</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>Camel Quarkus :: Examples :: Foo</name>
+    <description>Camel Quarkus Example :: Foo</description>
+
+    <properties>
+        <quarkus.platform.version>3.8.5</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>${camel-quarkus.platform.group-id}</groupId>
+                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
+                <version>${camel-quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-bean</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-log</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-timer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.artemis</groupId>
+            <artifactId>quarkus-artemis-jms</artifactId>
+            <version>3.4.2.redhat-00001</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+        </profile>
+        <profile>
+            <id>kubernetes</id>
+        </profile>
+        <profile>
+            <id>openshift</id>
+        </profile>
+    </profiles>
+</project>

--- a/prod-maven-plugin/src/test/examples/community/foo/src/main/java/org/acme/Foo.java
+++ b/prod-maven-plugin/src/test/examples/community/foo/src/main/java/org/acme/Foo.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 CQ Maven Plugin
+ * project contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.acme;
+
+public class Foo {
+}

--- a/prod-maven-plugin/src/test/examples/community/foo/src/main/java/org/acme/FooBar.java
+++ b/prod-maven-plugin/src/test/examples/community/foo/src/main/java/org/acme/FooBar.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 CQ Maven Plugin
+ * project contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.acme;
+
+public class FooBar {
+}

--- a/prod-maven-plugin/src/test/examples/community/foo/src/main/resources/kubernetes/kubernetes.yml
+++ b/prod-maven-plugin/src/test/examples/community/foo/src/main/resources/kubernetes/kubernetes.yml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2020 CQ Maven Plugin
+# project contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+some:
+  fake:
+    configuration

--- a/prod-maven-plugin/src/test/examples/community/foo/src/main/resources/kubernetes/openshift.yml
+++ b/prod-maven-plugin/src/test/examples/community/foo/src/main/resources/kubernetes/openshift.yml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2020 CQ Maven Plugin
+# project contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+some:
+  fake:
+    configuration

--- a/prod-maven-plugin/src/test/examples/product/foo/pom.xml
+++ b/prod-maven-plugin/src/test/examples/product/foo/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 CQ Maven Plugin
+    project contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.camel.quarkus</groupId>
+    <artifactId>camel-quarkus-Foo</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>Camel Quarkus :: Examples :: Foo</name>
+    <description>Camel Quarkus Example :: Foo</description>
+
+    <properties>
+        <quarkus.platform.version>1.0.0.redhat-00001</quarkus.platform.version>
+        <camel-quarkus.platform.version>${quarkus.platform.version}</camel-quarkus.platform.version>
+
+        <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <camel-quarkus.platform.group-id>${quarkus.platform.group-id}</camel-quarkus.platform.group-id>
+        <camel-quarkus.platform.artifact-id>quarkus-camel-bom</camel-quarkus.platform.artifact-id>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>${camel-quarkus.platform.group-id}</groupId>
+                <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
+                <version>${camel-quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-bean</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-log</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+        </profile>
+    </profiles>
+</project>

--- a/prod-maven-plugin/src/test/examples/product/foo/src/main/java/org/acme/Foo.java
+++ b/prod-maven-plugin/src/test/examples/product/foo/src/main/java/org/acme/Foo.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 CQ Maven Plugin
+ * project contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.acme;
+
+public class Foo {
+}

--- a/prod-maven-plugin/src/test/java/org/l2x6/cq/maven/prod/SyncExamplesFromUpstreamMojoTest.java
+++ b/prod-maven-plugin/src/test/java/org/l2x6/cq/maven/prod/SyncExamplesFromUpstreamMojoTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2020 CQ Maven Plugin
+ * project contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.l2x6.cq.maven.prod;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Profile;
+import org.apache.maven.model.Repository;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.l2x6.cq.common.CqCommonUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SyncExamplesFromUpstreamMojoTest {
+    private static final Path TMP_DIR = Paths.get(System.getProperty("java.io.tmpdir")).resolve("example-project-sync-testing");
+    private static final Path UPSTREAM_EXAMPLES_DIR = TMP_DIR.resolve("upstream/camel-quarkus-examples-3.8.x");
+    private static final Path PRODUCT_EXAMPLES_DIR = TMP_DIR.resolve("product/camel-quarkus-examples-3.8.x");
+    private static final Path EXAMPLES = Paths.get("src/test/examples/community");
+    private static final Path EXAMPLE_FOO = EXAMPLES.resolve("foo");
+    private static final Path EXAMPLE_BAR = EXAMPLES.resolve("bar");
+
+    @BeforeEach
+    public void beforeEach() {
+        try {
+            Files.createDirectories(UPSTREAM_EXAMPLES_DIR);
+            Files.createDirectories(PRODUCT_EXAMPLES_DIR);
+            FileUtils.copyDirectory(EXAMPLE_FOO.toFile(), UPSTREAM_EXAMPLES_DIR.resolve("foo").toFile());
+            FileUtils.copyDirectory(EXAMPLE_BAR.toFile(), UPSTREAM_EXAMPLES_DIR.resolve("bar").toFile());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterEach
+    public void afterEach() {
+        try {
+            FileUtils.deleteDirectory(TMP_DIR.toFile());
+        } catch (IOException e) {
+            // Ignored
+        }
+    }
+
+    @Test
+    void syncExamples() throws Exception {
+        SyncExamplesFromUpstreamMojo mojo = initMojo();
+
+        Map<String, Set<SyncExamplesFromUpstreamMojo.GAV>> projectDependencies = new TreeMap<>();
+        resolveDependencies(EXAMPLE_FOO, projectDependencies);
+        resolveDependencies(EXAMPLE_BAR, projectDependencies);
+        Files.walkFileTree(UPSTREAM_EXAMPLES_DIR, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                mojo.preSyncTransformers.stream()
+                        .filter(sourceTransformer -> sourceTransformer.canApply(file))
+                        .forEach(sourceTransformer -> sourceTransformer.apply(file));
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        // Perform project sync
+        mojo.syncProjects(projectDependencies);
+
+        // bar project should not be synced since it uses unproductized camel-quarkus-zookeeper
+        assertFalse(Files.exists(PRODUCT_EXAMPLES_DIR.resolve("bar")));
+
+        // foo should be synced as all dependencies are productized
+        Path projectFoo = PRODUCT_EXAMPLES_DIR.resolve("foo");
+        assertTrue(Files.exists(projectFoo));
+
+        // pom.xml should be updated with product versions
+        Model model = CqCommonUtils.readPom(projectFoo.resolve("pom.xml"), StandardCharsets.UTF_8);
+        Properties properties = model.getProperties();
+        assertEquals("3.8.0-redhat-00001", model.getVersion());
+        assertEquals("com.redhat.quarkus.platform", properties.getProperty("quarkus.platform.group-id"));
+        assertEquals("quarkus-bom", properties.getProperty("quarkus.platform.artifact-id"));
+        assertEquals("3.8.5.redhat-00003", properties.getProperty("quarkus.platform.version"));
+        assertEquals("${quarkus.platform.group-id}", properties.getProperty("camel-quarkus.platform.group-id"));
+        assertEquals("quarkus-camel-bom", properties.getProperty("camel-quarkus.platform.artifact-id"));
+        assertEquals("${quarkus.platform.version}", properties.getProperty("camel-quarkus.platform.version"));
+
+        // GA repositories should be added
+        List<Repository> repositories = model.getRepositories();
+        assertEquals(2, repositories.size());
+        assertEquals("redhat-ga-repository", repositories.get(0).getId());
+        assertEquals("https://maven.repository.redhat.com/ga/", repositories.get(0).getUrl());
+        assertTrue(repositories.get(0).getReleases().isEnabled());
+        assertFalse(repositories.get(0).getSnapshots().isEnabled());
+        assertEquals("redhat-earlyaccess-repository", repositories.get(1).getId());
+        assertEquals("https://maven.repository.redhat.com/earlyaccess/all/", repositories.get(1).getUrl());
+        assertTrue(repositories.get(1).getReleases().isEnabled());
+        assertFalse(repositories.get(1).getSnapshots().isEnabled());
+
+        List<Repository> pluginRepositories = model.getPluginRepositories();
+        assertEquals(2, repositories.size());
+        assertEquals("redhat-ga-repository", pluginRepositories.get(0).getId());
+        assertEquals("https://maven.repository.redhat.com/ga/", pluginRepositories.get(0).getUrl());
+        assertTrue(pluginRepositories.get(0).getReleases().isEnabled());
+        assertFalse(pluginRepositories.get(0).getSnapshots().isEnabled());
+        assertEquals("redhat-earlyaccess-repository", pluginRepositories.get(1).getId());
+        assertEquals("https://maven.repository.redhat.com/earlyaccess/all/", pluginRepositories.get(1).getUrl());
+        assertTrue(pluginRepositories.get(1).getReleases().isEnabled());
+        assertFalse(pluginRepositories.get(1).getSnapshots().isEnabled());
+
+        // kubernetes profile should not be present
+        List<Profile> profiles = model.getProfiles();
+        assertEquals(2, profiles.size());
+        assertEquals("native", profiles.get(0).getId());
+        assertEquals("openshift", profiles.get(1).getId());
+
+        // quarkus-artemis-jms should not have an explicit version
+        Optional<String> quarkusArtemisVersion = model.getDependencies()
+                .stream()
+                .filter(dependency -> dependency.getArtifactId().equals("quarkus-artemis-jms"))
+                .map(Dependency::getVersion)
+                .filter(Objects::nonNull)
+                .findFirst();
+        assertTrue(quarkusArtemisVersion.isEmpty());
+
+        // Only OpenShift cloud deployment instructions should remain in the README
+        String readme = Files.readString(projectFoo.resolve("README.adoc"));
+        assertTrue(readme.contains("Deploying to OpenShift"));
+        assertFalse(readme.contains("Deploying to Kubernetes"));
+
+        // Only OpenShift manifests should remain
+        assertFalse(Files.exists(projectFoo.resolve("src/main/resources/kubernetes/kubernetes.yml")));
+        assertTrue(Files.exists(projectFoo.resolve("src/main/resources/kubernetes/openshift.yml")));
+    }
+
+    private static SyncExamplesFromUpstreamMojo initMojo() {
+        SyncExamplesFromUpstreamMojo mojo = new SyncExamplesFromUpstreamMojo();
+        mojo.quarkusPlatformVersion = "3.8.5.redhat-00003";
+        mojo.quarkusPlatformGroupId = "com.redhat.quarkus.platform";
+        mojo.quarkusPlatformArtifactId = "quarkus-bom";
+        mojo.camelQuarkusPlatformArtifactId = "quarkus-camel-bom";
+        mojo.tmpDir = UPSTREAM_EXAMPLES_DIR.getParent().toFile();
+        mojo.syncToDir = PRODUCT_EXAMPLES_DIR.toFile();
+        mojo.setUpSourceTransformations();
+        return mojo;
+    }
+
+    private static void resolveDependencies(Path examplesDir,
+            Map<String, Set<SyncExamplesFromUpstreamMojo.GAV>> projectDependencies) {
+        Model model = CqCommonUtils.readPom(examplesDir.resolve("pom.xml"), StandardCharsets.UTF_8);
+        projectDependencies.put(examplesDir.getFileName().toString(), model.getDependencies()
+                .stream()
+                .map(dependency -> {
+                    String version = dependency.getVersion();
+                    if (version == null && !dependency.getArtifactId().equals("camel-quarkus-zookeeper")) {
+                        version = "1.0.0.redhat-00001";
+                    }
+
+                    Artifact artifact = new DefaultArtifact(
+                            dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + version);
+                    return new SyncExamplesFromUpstreamMojo.GAV(artifact, false);
+                })
+                .collect(Collectors.toUnmodifiableSet()));
+    }
+}

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.l2x6.cq</groupId>
         <artifactId>cq</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cq-test-utils</artifactId>


### PR DESCRIPTION
I originally created this as a standalone Quarkus command mode tool. But I thought it'd be better to have it with our other prod tooling. Hence a new mojo to sync CQ example projects from an upstream branch to the product fork.
