### PR TITLE
Change camel-community.version default property to camel-community-version to match camel's property style

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -99,7 +99,7 @@ Use `mvn help:describe` to see the full set of parameters.
                         <dependency>
                             <groupId>org.apache.camel</groupId>
                             <artifactId>camel-package-maven-plugin</artifactId>
-                            <version>${camel-community.version}</version>
+                            <version>${camel-community-version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -142,11 +142,11 @@ mvn org.l2x6.cq:cq-camel-prod-maven-plugin:camel-prod-excludes -N
             </plugin>
 ----
 
-A version property `<camel-community.version>3.14.1</camel-community.version>` needs to be added to the pom.xml for the maven plugin to execute successfully.
+A version property `<camel-community-version>3.14.1</camel-community-version>` needs to be added to the pom.xml for the maven plugin to execute successfully.
 
 From CAMEL_SPRING_BOOT_HOME, camel-spring-boot-prod-excludes is used to comment out modules that should not be productized.
 
-A version property `<camel-community.version>3.14.1</camel-community.version>` needs to be added to the pom.xml for the maven plugin to execute successfully.
+A version property `<camel-community-version>3.14.1</camel-community-version>` needs to be added to the pom.xml for the maven plugin to execute successfully.
 
 To invoke :
 
@@ -177,7 +177,7 @@ Configured in the pom.xml :
                     <dependency>
                         <groupId>org.apache.camel</groupId>
                         <artifactId>camel-package-maven-plugin</artifactId>
-                        <version>${camel-community.version}</version>
+                        <version>${camel-community-version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/camel-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/maven/prod/CamelProdExcludesMojo.java
+++ b/camel-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/maven/prod/CamelProdExcludesMojo.java
@@ -113,7 +113,7 @@ public class CamelProdExcludesMojo extends AbstractMojo {
         CAMEL_COMMUNITY_VERSION {
             @Override
             public String getExpectedVersion(String literalVersion) {
-                return "${camel-community.version}";
+                return "${camel-community-version}";
             }
         },
         LITERAL {
@@ -214,7 +214,7 @@ public class CamelProdExcludesMojo extends AbstractMojo {
     /**
      * @since 2.11.0
      */
-    @Parameter(property = "cq.camelCommunityVersion", defaultValue = "${camel-community.version}")
+    @Parameter(property = "cq.camelCommunityVersion", defaultValue = "${camel-community-version}")
     String camelCommunityVersion;
 
     Map<String, VersionStyle> versionStylesByPath;
@@ -287,7 +287,7 @@ public class CamelProdExcludesMojo extends AbstractMojo {
 
         final Path rootPomPath = workRoot.resolve("pom.xml");
         new PomTransformer(rootPomPath, charset, simpleElementWhitespace)
-                .transform(Transformation.addOrSetProperty("camel-community.version", camelCommunityVersion));
+                .transform(Transformation.addOrSetProperty("camel-community-version", camelCommunityVersion));
 
         final MavenSourceTree initialTree = MavenSourceTree.of(rootPomPath, charset, Dependency::isVirtual);
         final Predicate<Profile> profiles = ActiveProfiles.of();
@@ -301,7 +301,7 @@ public class CamelProdExcludesMojo extends AbstractMojo {
                     .transform(Transformation.setTextValue("/" +
                             PomTunerUtils.anyNs("plugin", "version") + "[.." + PomTunerUtils.anyNs("groupId")
                             + "/text() = 'org.apache.camel']",
-                            "${camel-community.version}"));
+                            "${camel-community-version}"));
         });
 
         /* Make a copy of the originalFullTree */
@@ -385,7 +385,7 @@ public class CamelProdExcludesMojo extends AbstractMojo {
         fullTree.unlinkModules(expandedIncludes, profiles, charset, simpleElementWhitespace,
                 (Set<String> unlinkModules) -> Transformation.commentModules(unlinkModules, MODULE_COMMENT));
 
-        /* Replace ${project.version} with ${camel-community.version} where necessary */
+        /* Replace ${project.version} with ${camel-community-version} where necessary */
         final MavenSourceTree reducedTree = MavenSourceTree.of(rootPomPath, charset, Dependency::isVirtual);
         reducedTree.getModulesByGa().values().forEach(module -> {
             final List<Transformation> transformations = new ArrayList<>();
@@ -427,7 +427,7 @@ public class CamelProdExcludesMojo extends AbstractMojo {
                     .transform(Transformation.setTextValue("/" +
                             PomTunerUtils.anyNs("dependency", "version") + "[.." + PomTunerUtils.anyNs("artifactId")
                             + "/text() = 'camel-buildtools']",
-                            "${camel-community.version}"));
+                            "${camel-community-version}"));
         });
 
         if (isChecking() && onCheckFailure != OnFailure.IGNORE) {

--- a/camel-spring-boot-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/spring/boot/maven/prod/CamelSpringBootProdExcludesMojo.java
+++ b/camel-spring-boot-prod-maven-plugin/src/main/java/org/l2x6/cq/camel/spring/boot/maven/prod/CamelSpringBootProdExcludesMojo.java
@@ -370,7 +370,7 @@ public class CamelSpringBootProdExcludesMojo extends AbstractMojo {
                                         .ifPresent(transformations::add);
                             });
 
-                    /* We do not productize camel test-infra - we need to set these to ${camel-community.version} */
+                    /* We do not productize camel test-infra - we need to set these to ${camel-community-version} */
                     profile.getDependencies().stream()
                             .filter(dep -> "org.apache.camel".equals(dep.getGroupId().asConstant())
                                     && "test-jar".equals(dep.getType())
@@ -382,7 +382,7 @@ public class CamelSpringBootProdExcludesMojo extends AbstractMojo {
                                 final VersionStyle vs = versionStylesByPath.get(module.getPomPath());
 
                                 transformations.add(Transformation.setDependencyVersion(profile.getId(),
-                                        "${camel-community.version}", Collections.singletonList(ga)));
+                                        "${camel-community-version}", Collections.singletonList(ga)));
                             });
                 }
 

--- a/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/ProdExcludesMojo.java
+++ b/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/ProdExcludesMojo.java
@@ -125,7 +125,7 @@ public class ProdExcludesMojo extends AbstractMojo {
 
     public enum CamelEdition {
         PRODUCT("${camel.version}"),
-        COMMUNITY("${camel-community.version}");
+        COMMUNITY("${camel-community-version}");
 
         CamelEdition(String versionExpression) {
             this.versionExpression = versionExpression;

--- a/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/ProdInitMojo.java
+++ b/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/ProdInitMojo.java
@@ -195,8 +195,8 @@ public class ProdInitMojo extends AbstractMojo {
                     /* Add some community props */
                     final ContainerElement props = context.getOrAddContainerElement("properties");
 
-                    getLog().info("Adding to pom.xml: camel-community.version property");
-                    props.addChildTextElementIfNeeded("camel-community.version",
+                    getLog().info("Adding to pom.xml: camel-community-version property");
+                    props.addChildTextElementIfNeeded("camel-community-version",
                             "${camel.major.minor}." + camelVersion.split("\\.")[2],
                             Comparator.comparing(Map.Entry::getKey, Comparators.before("camel.version")));
 
@@ -258,7 +258,7 @@ public class ProdInitMojo extends AbstractMojo {
                     getLog().info("Adding to pom.xml: product module");
                     modules.addChildTextElement("module", "product");
 
-                    /* Change the version of camel-build-tools under license-maven-plugin to camel-community.version */
+                    /* Change the version of camel-build-tools under license-maven-plugin to camel-community-version */
                     final ContainerElement managedPlugins = context.getOrAddContainerElements("build", "pluginManagement",
                             "plugins");
                     final ContainerElement licensePlugin = managedPlugins.childElementsStream()
@@ -271,7 +271,7 @@ public class ProdInitMojo extends AbstractMojo {
                     final ContainerElement buildToolsDep = licensePlugin
                             .getOrAddChildContainerElement("dependencies")
                             .getOrAddChildContainerElement("dependency");
-                    final String camelCommunityVersion = "${camel-community.version}";
+                    final String camelCommunityVersion = "${camel-community-version}";
                     getLog().info("Setting version in pom.xml: camel-buildtools "
                             + buildToolsDep.getChildContainerElement("version").get().getNode().getTextContent() + " -> "
                             + camelCommunityVersion);
@@ -422,9 +422,9 @@ public class ProdInitMojo extends AbstractMojo {
                             .filter(gavtcs -> "camel-salesforce-maven-plugin".equals(gavtcs.getArtifactId())
                                     || "camel-servicenow-maven-plugin".equals(gavtcs.getArtifactId()))
                             .peek(gavtcs -> getLog()
-                                    .info("Updating " + gavtcs.getArtifactId() + " version to ${camel-community.version}"))
+                                    .info("Updating " + gavtcs.getArtifactId() + " version to ${camel-community-version}"))
                             .map(PomTransformer.NodeGavtcs::getNode)
-                            .forEach(containerElement -> containerElement.setVersion("${camel-community.version}"));
+                            .forEach(containerElement -> containerElement.setVersion("${camel-community-version}"));
                 });
 
         /*

--- a/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/TransitiveDependenciesMojo.java
+++ b/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/TransitiveDependenciesMojo.java
@@ -257,7 +257,7 @@ public class TransitiveDependenciesMojo {
                     .append("</groupId>\n                <artifactId>")
                     .append(ga.getArtifactId())
                     .append("</artifactId>\n                <version>")
-                    .append(prodTransitiveGas.contains(ga) ? "${camel.version}" : "${camel-community.version}")
+                    .append(prodTransitiveGas.contains(ga) ? "${camel.version}" : "${camel-community-version}")
                     .append("</version>\n            </dependency>"));
             throw new RuntimeException(sb.toString());
         }

--- a/prod-maven-plugin/src/test/expected/check-initial/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-initial/pom.xml
@@ -42,7 +42,7 @@
         <!-- Primary dependencies - maintained manually -->
         <camel.major.minor>3.11</camel.major.minor> <!-- run after each change: cd docs && mvnd validate -->
         <camel.version>${camel.major.minor}.1-fuse1</camel.version>
-        <camel-community.version>${camel.major.minor}.1</camel-community.version>
+        <camel-community-version>${camel.major.minor}.1</camel-community-version>
         <camel.docs.components.xref>${camel.major.minor}.x@components</camel.docs.components.xref><!-- the version in Camel's docs/components/antora.yml -->
         <camel.docs.branch>camel-${camel.major.minor}.x</camel.docs.branch><!-- The stable branch on which our Antora docs depends -->
 

--- a/prod-maven-plugin/src/test/expected/check-initial/target/prod-excludes-work/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-initial/target/prod-excludes-work/pom.xml
@@ -42,7 +42,7 @@
         <!-- Primary dependencies - maintained manually -->
         <camel.major.minor>3.11</camel.major.minor> <!-- run after each change: cd docs && mvnd validate -->
         <camel.version>${camel.major.minor}.1-fuse1</camel.version>
-        <camel-community.version>${camel.major.minor}.1</camel-community.version>
+        <camel-community-version>${camel.major.minor}.1</camel-community-version>
         <camel.docs.components.xref>${camel.major.minor}.x@components</camel.docs.components.xref><!-- the version in Camel's docs/components/antora.yml -->
         <camel.docs.branch>camel-${camel.major.minor}.x</camel.docs.branch><!-- The stable branch on which our Antora docs depends -->
 

--- a/prod-maven-plugin/src/test/expected/check-initial/target/prod-excludes-work/poms/bom/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-initial/target/prod-excludes-work/poms/bom/pom.xml
@@ -110,32 +110,32 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-direct</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-avro</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-asn1</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-catalog</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-cloud</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-log</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
 
             <!--$ org.apache.camel.quarkus $-->

--- a/prod-maven-plugin/src/test/expected/check-new-supported-extension/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-new-supported-extension/pom.xml
@@ -42,7 +42,7 @@
         <!-- Primary dependencies - maintained manually -->
         <camel.major.minor>3.11</camel.major.minor> <!-- run after each change: cd docs && mvnd validate -->
         <camel.version>${camel.major.minor}.1-fuse1</camel.version>
-        <camel-community.version>${camel.major.minor}.1</camel-community.version>
+        <camel-community-version>${camel.major.minor}.1</camel-community-version>
         <camel.docs.components.xref>${camel.major.minor}.x@components</camel.docs.components.xref><!-- the version in Camel's docs/components/antora.yml -->
         <camel.docs.branch>camel-${camel.major.minor}.x</camel.docs.branch><!-- The stable branch on which our Antora docs depends -->
 

--- a/prod-maven-plugin/src/test/expected/check-new-supported-extension/poms/bom/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-new-supported-extension/poms/bom/pom.xml
@@ -110,32 +110,32 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-direct</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-avro</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-asn1</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-catalog</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-cloud</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-log</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
 
             <!--$ org.apache.camel.quarkus $-->

--- a/prod-maven-plugin/src/test/expected/check-new-supported-extension/target/prod-excludes-work/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-new-supported-extension/target/prod-excludes-work/pom.xml
@@ -42,7 +42,7 @@
         <!-- Primary dependencies - maintained manually -->
         <camel.major.minor>3.11</camel.major.minor> <!-- run after each change: cd docs && mvnd validate -->
         <camel.version>${camel.major.minor}.1-fuse1</camel.version>
-        <camel-community.version>${camel.major.minor}.1</camel-community.version>
+        <camel-community-version>${camel.major.minor}.1</camel-community-version>
         <camel.docs.components.xref>${camel.major.minor}.x@components</camel.docs.components.xref><!-- the version in Camel's docs/components/antora.yml -->
         <camel.docs.branch>camel-${camel.major.minor}.x</camel.docs.branch><!-- The stable branch on which our Antora docs depends -->
 

--- a/prod-maven-plugin/src/test/expected/check-new-supported-extension/target/prod-excludes-work/poms/bom/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-new-supported-extension/target/prod-excludes-work/poms/bom/pom.xml
@@ -110,32 +110,32 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-direct</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-avro</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-asn1</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-catalog</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-cloud</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-log</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
 
             <!--$ org.apache.camel.quarkus $-->

--- a/prod-maven-plugin/src/test/expected/prod-excludes-initial/pom.xml
+++ b/prod-maven-plugin/src/test/expected/prod-excludes-initial/pom.xml
@@ -42,7 +42,7 @@
         <!-- Primary dependencies - maintained manually -->
         <camel.major.minor>3.11</camel.major.minor> <!-- run after each change: cd docs && mvnd validate -->
         <camel.version>${camel.major.minor}.1-fuse1</camel.version>
-        <camel-community.version>${camel.major.minor}.1</camel-community.version>
+        <camel-community-version>${camel.major.minor}.1</camel-community-version>
         <camel.docs.components.xref>${camel.major.minor}.x@components</camel.docs.components.xref><!-- the version in Camel's docs/components/antora.yml -->
         <camel.docs.branch>camel-${camel.major.minor}.x</camel.docs.branch><!-- The stable branch on which our Antora docs depends -->
 

--- a/prod-maven-plugin/src/test/expected/prod-excludes-initial/poms/bom/pom.xml
+++ b/prod-maven-plugin/src/test/expected/prod-excludes-initial/poms/bom/pom.xml
@@ -110,32 +110,32 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-direct</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-avro</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-asn1</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-catalog</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-cloud</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-log</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
 
             <!--$ org.apache.camel.quarkus $-->

--- a/prod-maven-plugin/src/test/expected/prod-excludes-new-supported-extension/pom.xml
+++ b/prod-maven-plugin/src/test/expected/prod-excludes-new-supported-extension/pom.xml
@@ -42,7 +42,7 @@
         <!-- Primary dependencies - maintained manually -->
         <camel.major.minor>3.11</camel.major.minor> <!-- run after each change: cd docs && mvnd validate -->
         <camel.version>${camel.major.minor}.1-fuse1</camel.version>
-        <camel-community.version>${camel.major.minor}.1</camel-community.version>
+        <camel-community-version>${camel.major.minor}.1</camel-community-version>
         <camel.docs.components.xref>${camel.major.minor}.x@components</camel.docs.components.xref><!-- the version in Camel's docs/components/antora.yml -->
         <camel.docs.branch>camel-${camel.major.minor}.x</camel.docs.branch><!-- The stable branch on which our Antora docs depends -->
 

--- a/prod-maven-plugin/src/test/expected/prod-excludes-new-supported-extension/poms/bom/pom.xml
+++ b/prod-maven-plugin/src/test/expected/prod-excludes-new-supported-extension/poms/bom/pom.xml
@@ -110,32 +110,32 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-direct</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-avro</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-asn1</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-catalog</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-cloud</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-log</artifactId>
-                <version>${camel-community.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
 
             <!--$ org.apache.camel.quarkus $-->

--- a/prod-maven-plugin/src/test/projects/prod-excludes/pom.xml
+++ b/prod-maven-plugin/src/test/projects/prod-excludes/pom.xml
@@ -42,7 +42,7 @@
         <!-- Primary dependencies - maintained manually -->
         <camel.major.minor>3.11</camel.major.minor> <!-- run after each change: cd docs && mvnd validate -->
         <camel.version>${camel.major.minor}.1-fuse1</camel.version>
-        <camel-community.version>${camel.major.minor}.1</camel-community.version>
+        <camel-community-version>${camel.major.minor}.1</camel-community-version>
         <camel.docs.components.xref>${camel.major.minor}.x@components</camel.docs.components.xref><!-- the version in Camel's docs/components/antora.yml -->
         <camel.docs.branch>camel-${camel.major.minor}.x</camel.docs.branch><!-- The stable branch on which our Antora docs depends -->
 


### PR DESCRIPTION
Camel has a default x-y-z property style, and it is backed up by sync-properties-maven-plugin : 

https://github.com/apache/camel/blob/main/tooling/maven/sync-properties-maven-plugin/src/main/java/org/apache/camel/maven/sync/properties/SyncPropertiesMojo.java#L177-L191

sync-properties-maven-plugin checks whether properties use this style and only properties with this format are synced into camel-dependencies.     While I don't think it matters if camel-community.version gets synced into camel-dependencies, we do need to pass that check in sync-properties-maven-plugin - so it would be good to change the property to match the x-y-z property style.