### PR TITLE
Comment out modules from standard-build profile

### DIFF
--- a/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/ProdExcludesMojo.java
+++ b/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/ProdExcludesMojo.java
@@ -30,6 +30,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
@@ -710,9 +711,14 @@ public class ProdExcludesMojo extends AbstractMojo {
                 Arrays.asList("integration-tests", "integration-tests-jvm", "integration-test-groups"));
         final Set<String> testParentArtifactIds = testParents.stream().map(base -> "camel-quarkus-" + base)
                 .collect(Collectors.toSet());
+        final Collection<String> modulesFromStandardBuild = Arrays.asList("docs", "integration-test-groups",
+                "integration-tests-jvm");
+
         final Path rootPomPath = workRoot.resolve("pom.xml");
         new PomTransformer(rootPomPath, charset, simpleElementWhitespace)
                 .transform(Transformation.commentModules(testParents, MODULE_COMMENT));
+        new PomTransformer(rootPomPath, charset, simpleElementWhitespace)
+                .transform(Transformation.commentModulesInProfile("standard-build", modulesFromStandardBuild, MODULE_COMMENT));
         final Set<Ga> expandedIncludesWithoutTests = expandedIncludes.stream()
                 .filter(ga -> !tests.containsKey(ga) && !testParentArtifactIds.contains(ga.getArtifactId()))
                 .collect(Collectors.toCollection(LinkedHashSet<Ga>::new));

--- a/prod-maven-plugin/src/test/expected/check-initial/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-initial/pom.xml
@@ -752,6 +752,17 @@
             </build>
         </profile>
         <profile>
+            <id>standard-build</id>
+            <activation>
+                <property>
+                    <name>!apache-release</name>
+                </property>
+            </activation>
+            <modules>
+                <module>integration-tests-jvm</module>
+            </modules>
+        </profile>
+        <profile>
             <id>apache-release</id>
             <activation>
                 <property>

--- a/prod-maven-plugin/src/test/expected/check-initial/target/prod-excludes-work/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-initial/target/prod-excludes-work/pom.xml
@@ -752,6 +752,17 @@
             </build>
         </profile>
         <profile>
+            <id>standard-build</id>
+            <activation>
+                <property>
+                    <name>!apache-release</name>
+                </property>
+            </activation>
+            <modules>
+                <!-- <module>integration-tests-jvm</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+            </modules>
+        </profile>
+        <profile>
             <id>apache-release</id>
             <activation>
                 <property>

--- a/prod-maven-plugin/src/test/expected/check-new-supported-extension/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-new-supported-extension/pom.xml
@@ -752,6 +752,17 @@
             </build>
         </profile>
         <profile>
+            <id>standard-build</id>
+            <activation>
+                <property>
+                    <name>!apache-release</name>
+                </property>
+            </activation>
+            <modules>
+                <!-- <module>integration-tests-jvm</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+            </modules>
+        </profile>
+        <profile>
             <id>apache-release</id>
             <activation>
                 <property>

--- a/prod-maven-plugin/src/test/expected/check-new-supported-extension/target/prod-excludes-work/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-new-supported-extension/target/prod-excludes-work/pom.xml
@@ -752,6 +752,17 @@
             </build>
         </profile>
         <profile>
+            <id>standard-build</id>
+            <activation>
+                <property>
+                    <name>!apache-release</name>
+                </property>
+            </activation>
+            <modules>
+                <!-- <module>integration-tests-jvm</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+            </modules>
+        </profile>
+        <profile>
             <id>apache-release</id>
             <activation>
                 <property>

--- a/prod-maven-plugin/src/test/expected/prod-excludes-initial/pom.xml
+++ b/prod-maven-plugin/src/test/expected/prod-excludes-initial/pom.xml
@@ -752,6 +752,17 @@
             </build>
         </profile>
         <profile>
+            <id>standard-build</id>
+            <activation>
+                <property>
+                    <name>!apache-release</name>
+                </property>
+            </activation>
+            <modules>
+                <!-- <module>integration-tests-jvm</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+            </modules>
+        </profile>
+        <profile>
             <id>apache-release</id>
             <activation>
                 <property>

--- a/prod-maven-plugin/src/test/expected/prod-excludes-new-supported-extension/pom.xml
+++ b/prod-maven-plugin/src/test/expected/prod-excludes-new-supported-extension/pom.xml
@@ -752,6 +752,17 @@
             </build>
         </profile>
         <profile>
+            <id>standard-build</id>
+            <activation>
+                <property>
+                    <name>!apache-release</name>
+                </property>
+            </activation>
+            <modules>
+                <!-- <module>integration-tests-jvm</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+            </modules>
+        </profile>
+        <profile>
             <id>apache-release</id>
             <activation>
                 <property>

--- a/prod-maven-plugin/src/test/projects/prod-excludes/pom.xml
+++ b/prod-maven-plugin/src/test/projects/prod-excludes/pom.xml
@@ -752,6 +752,17 @@
             </build>
         </profile>
         <profile>
+            <id>standard-build</id>
+            <activation>
+                <property>
+                    <name>!apache-release</name>
+                </property>
+            </activation>
+            <modules>
+                <module>integration-tests-jvm</module>
+            </modules>
+        </profile>
+        <profile>
             <id>apache-release</id>
             <activation>
                 <property>


### PR DESCRIPTION
Comment out modules in standard-build profile.

This PR requires following change in pom-tuner https://github.com/l2x6/pom-tuner/pull/165.
Compilation fails without it.