### PR TITLE
Introduce FlattenBomMojo.resolutionExcludes

### DIFF
--- a/maven-plugin/src/main/java/org/l2x6/cq/maven/FlattenBomMojo.java
+++ b/maven-plugin/src/main/java/org/l2x6/cq/maven/FlattenBomMojo.java
@@ -136,6 +136,15 @@ public class FlattenBomMojo extends AbstractMojo {
     List<String> resolutionEntryPointExcludes;
 
     /**
+     * A list of {@code groupId:artifactId:version:type:classifier:scope} patterns whose matching entries will be
+     * removed from the set selected by {@link #resolutionEntryPointIncludes} and {@link #resolutionEntryPointExcludes}.
+     *
+     * @since 4.17.0
+     */
+    @Parameter(property = "cq.resolutionExcludes")
+    List<String> resolutionExcludes;
+
+    /**
      * As list of GAV patterns whose origin will be logged. Useful when searching on which BOM entry some specific
      * exclusion needs to be placed.
      *
@@ -387,6 +396,7 @@ public class FlattenBomMojo extends AbstractMojo {
         new FlattenBomTask(
                 resolutionEntryPointIncludes,
                 resolutionEntryPointExcludes,
+                resolutionExcludes,
                 resolutionSuspects,
                 originExcludes,
                 bomEntryTransformations,

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <maven.shared.invoker>3.3.0</maven.shared.invoker>
         <maven.shared.utils>3.4.2</maven.shared.utils>
         <mockito.version>5.15.2</mockito.version>
-        <pom-tuner.version>4.4.0</pom-tuner.version>
+        <pom-tuner.version>4.5.0</pom-tuner.version>
         <javax.inject.version>1</javax.inject.version>
         <jdom2.version>2.0.6.1</jdom2.version>
         <jgit.version>7.1.0.202411261347-r</jgit.version>

--- a/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/ProdExcludesMojo.java
+++ b/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/ProdExcludesMojo.java
@@ -1227,6 +1227,7 @@ public class ProdExcludesMojo extends AbstractMojo {
             final Path flattenedBomPath = new FlattenBomTask(
                     childList(config, "resolutionEntryPointIncludes"),
                     childList(config, "resolutionEntryPointExcludes"),
+                    childList(config, "resolutionExcludes"),
                     childList(config, "resolutionSuspects"),
                     childList(config, "originExcludes"),
                     bomEntryTransformations,


### PR DESCRIPTION
@jamesnetherton the new POM Tuner 4.5.0 supports filtering by type, classifier and scope. I have sketched here how it could work in cq-maven-plugin. Would you like to test against your use case? Feel free to fix whatever needed and release 4.17.0 if it works for you. 