### PR TITLE
Remove redundant prod-init step to add integration-tests-support/messaging to the list of project modules

### DIFF
--- a/maven-plugin/src/test/expected/set-versions-basic/tooling/test-list/pom.xml
+++ b/maven-plugin/src/test/expected/set-versions-basic/tooling/test-list/pom.xml
@@ -60,14 +60,6 @@
                                 <exclude>main-command-mode/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
-                            </excludes>
-                        </fileSet>
-                        <fileSet>
-                            <directory>${basedir}/../../integration-tests-support</directory>
-                            <includes>
-                                <include>*/pom.xml</include>
-                            </includes>
-                            <excludes>
                                 <exclude>messaging/pom.xml</exclude>
                             </excludes>
                         </fileSet>

--- a/maven-plugin/src/test/projects/set-versions/tooling/test-list/pom.xml
+++ b/maven-plugin/src/test/projects/set-versions/tooling/test-list/pom.xml
@@ -60,14 +60,6 @@
                                 <exclude>main-command-mode/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
-                            </excludes>
-                        </fileSet>
-                        <fileSet>
-                            <directory>${basedir}/../../integration-tests-support</directory>
-                            <includes>
-                                <include>*/pom.xml</include>
-                            </includes>
-                            <excludes>
                                 <exclude>messaging/pom.xml</exclude>
                             </excludes>
                         </fileSet>

--- a/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/ProdInitMojo.java
+++ b/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/ProdInitMojo.java
@@ -250,13 +250,6 @@ public class ProdInitMojo extends AbstractMojo {
                     final ContainerElement profileParent = context.getOrAddProfileParent(null);
                     final ContainerElement modules = profileParent.getOrAddChildContainerElement("modules");
 
-                    /* Add integration-tests/message module.
-                       camel-quarkus-integration-test-messaging-jms needed to be productized as a transitive dependency
-                       of jms-(artemis|qpid-jms|ibmmq)-client tests.
-                     */
-                    getLog().info("Adding to pom.xml: integration-tests-support/messaging module");
-                    modules.addChildTextElement("module", "integration-tests-support/messaging");
-
                     /* Add product module */
                     getLog().info("Adding to pom.xml: product module");
                     modules.addChildTextElement("module", "product");

--- a/prod-maven-plugin/src/test/expected/check-initial/product/src/main/resources/camel-quarkus-product-source.json
+++ b/prod-maven-plugin/src/test/expected/check-initial/product/src/main/resources/camel-quarkus-product-source.json
@@ -21,7 +21,6 @@
                 "integration-tests-jvm/*/pom.xml"
             ],
             "excludes": [
-                "integration-tests/messaging/pom.xml",
                 "integration-tests/*-grouped/pom.xml"
             ]
         }

--- a/prod-maven-plugin/src/test/expected/check-initial/target/prod-excludes-work/tooling/test-list/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-initial/target/prod-excludes-work/tooling/test-list/pom.xml
@@ -60,16 +60,8 @@
                                 <exclude>main-command-mode/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
-                                <exclude>js-dsl/pom.xml</exclude>
-                            </excludes>
-                        </fileSet>
-                        <fileSet>
-                            <directory>${basedir}/../../integration-tests-support</directory>
-                            <includes>
-                                <include>*/pom.xml</include>
-                            </includes>
-                            <excludes>
                                 <exclude>messaging/pom.xml</exclude>
+                                <exclude>js-dsl/pom.xml</exclude>
                             </excludes>
                         </fileSet>
                     </fileSets>

--- a/prod-maven-plugin/src/test/expected/check-initial/tooling/test-list/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-initial/tooling/test-list/pom.xml
@@ -60,14 +60,6 @@
                                 <exclude>main-command-mode/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
-                            </excludes>
-                        </fileSet>
-                        <fileSet>
-                            <directory>${basedir}/../../integration-tests-support</directory>
-                            <includes>
-                                <include>*/pom.xml</include>
-                            </includes>
-                            <excludes>
                                 <exclude>messaging/pom.xml</exclude>
                             </excludes>
                         </fileSet>

--- a/prod-maven-plugin/src/test/expected/check-new-supported-extension/product/src/main/resources/camel-quarkus-product-source.json
+++ b/prod-maven-plugin/src/test/expected/check-new-supported-extension/product/src/main/resources/camel-quarkus-product-source.json
@@ -21,7 +21,6 @@
                 "integration-tests-jvm/*/pom.xml"
             ],
             "excludes": [
-                "integration-tests/messaging/pom.xml",
                 "integration-tests/*-grouped/pom.xml"
             ]
         }

--- a/prod-maven-plugin/src/test/expected/check-new-supported-extension/target/prod-excludes-work/tooling/test-list/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-new-supported-extension/target/prod-excludes-work/tooling/test-list/pom.xml
@@ -60,16 +60,8 @@
                                 <exclude>main-command-mode/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
-                                <exclude>js-dsl/pom.xml</exclude>
-                            </excludes>
-                        </fileSet>
-                        <fileSet>
-                            <directory>${basedir}/../../integration-tests-support</directory>
-                            <includes>
-                                <include>*/pom.xml</include>
-                            </includes>
-                            <excludes>
                                 <exclude>messaging/pom.xml</exclude>
+                                <exclude>js-dsl/pom.xml</exclude>
                             </excludes>
                         </fileSet>
                     </fileSets>

--- a/prod-maven-plugin/src/test/expected/check-new-supported-extension/tooling/test-list/pom.xml
+++ b/prod-maven-plugin/src/test/expected/check-new-supported-extension/tooling/test-list/pom.xml
@@ -60,16 +60,8 @@
                                 <exclude>main-command-mode/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
-                                <exclude>js-dsl/pom.xml</exclude>
-                            </excludes>
-                        </fileSet>
-                        <fileSet>
-                            <directory>${basedir}/../../integration-tests-support</directory>
-                            <includes>
-                                <include>*/pom.xml</include>
-                            </includes>
-                            <excludes>
                                 <exclude>messaging/pom.xml</exclude>
+                                <exclude>js-dsl/pom.xml</exclude>
                             </excludes>
                         </fileSet>
                     </fileSets>

--- a/prod-maven-plugin/src/test/expected/prod-excludes-initial/product/src/main/resources/camel-quarkus-product-source.json
+++ b/prod-maven-plugin/src/test/expected/prod-excludes-initial/product/src/main/resources/camel-quarkus-product-source.json
@@ -21,7 +21,6 @@
                 "integration-tests-jvm/*/pom.xml"
             ],
             "excludes": [
-                "integration-tests/messaging/pom.xml",
                 "integration-tests/*-grouped/pom.xml"
             ]
         }

--- a/prod-maven-plugin/src/test/expected/prod-excludes-initial/tooling/test-list/pom.xml
+++ b/prod-maven-plugin/src/test/expected/prod-excludes-initial/tooling/test-list/pom.xml
@@ -60,16 +60,8 @@
                                 <exclude>main-command-mode/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
-                                <exclude>js-dsl/pom.xml</exclude>
-                            </excludes>
-                        </fileSet>
-                        <fileSet>
-                            <directory>${basedir}/../../integration-tests-support</directory>
-                            <includes>
-                                <include>*/pom.xml</include>
-                            </includes>
-                            <excludes>
                                 <exclude>messaging/pom.xml</exclude>
+                                <exclude>js-dsl/pom.xml</exclude>
                             </excludes>
                         </fileSet>
                     </fileSets>

--- a/prod-maven-plugin/src/test/expected/prod-excludes-new-supported-extension/product/src/main/resources/camel-quarkus-product-source.json
+++ b/prod-maven-plugin/src/test/expected/prod-excludes-new-supported-extension/product/src/main/resources/camel-quarkus-product-source.json
@@ -28,7 +28,6 @@
                 "integration-tests-jvm/*/pom.xml"
             ],
             "excludes": [
-                "integration-tests/messaging/pom.xml",
                 "integration-tests/*-grouped/pom.xml"
             ]
         }

--- a/prod-maven-plugin/src/test/expected/prod-excludes-new-supported-extension/tooling/test-list/pom.xml
+++ b/prod-maven-plugin/src/test/expected/prod-excludes-new-supported-extension/tooling/test-list/pom.xml
@@ -60,16 +60,8 @@
                                 <exclude>main-command-mode/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
-                                <exclude>js-dsl/pom.xml</exclude>
-                            </excludes>
-                        </fileSet>
-                        <fileSet>
-                            <directory>${basedir}/../../integration-tests-support</directory>
-                            <includes>
-                                <include>*/pom.xml</include>
-                            </includes>
-                            <excludes>
                                 <exclude>messaging/pom.xml</exclude>
+                                <exclude>js-dsl/pom.xml</exclude>
                             </excludes>
                         </fileSet>
                     </fileSets>

--- a/prod-maven-plugin/src/test/projects/prod-excludes/product/src/main/resources/camel-quarkus-product-source.json
+++ b/prod-maven-plugin/src/test/projects/prod-excludes/product/src/main/resources/camel-quarkus-product-source.json
@@ -21,7 +21,6 @@
                 "integration-tests-jvm/*/pom.xml"
             ],
             "excludes": [
-                "integration-tests/messaging/pom.xml",
                 "integration-tests/*-grouped/pom.xml"
             ]
         }

--- a/prod-maven-plugin/src/test/projects/prod-excludes/tooling/test-list/pom.xml
+++ b/prod-maven-plugin/src/test/projects/prod-excludes/tooling/test-list/pom.xml
@@ -60,14 +60,6 @@
                                 <exclude>main-command-mode/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
                                 <exclude>main-unknown-args-fail/pom.xml</exclude>
-                            </excludes>
-                        </fileSet>
-                        <fileSet>
-                            <directory>${basedir}/../../integration-tests-support</directory>
-                            <includes>
-                                <include>*/pom.xml</include>
-                            </includes>
-                            <excludes>
                                 <exclude>messaging/pom.xml</exclude>
                             </excludes>
                         </fileSet>

--- a/prod-maven-plugin/src/test/resources/camel-quarkus-product-source-with-new-extension.json
+++ b/prod-maven-plugin/src/test/resources/camel-quarkus-product-source-with-new-extension.json
@@ -28,7 +28,6 @@
                 "integration-tests-jvm/*/pom.xml"
             ],
             "excludes": [
-                "integration-tests/messaging/pom.xml",
                 "integration-tests/*-grouped/pom.xml"
             ]
         }


### PR DESCRIPTION
Rethinking #614 after some brief testing, I don't think the step to add messaging-common to the list of CQ project modules is required. It's already there.

It was only an issue in older CQ releases before https://github.com/apache/camel-quarkus/commit/d43943fdd166a3f7e17ad350db04dd0773653366.