### PR TITLE
Do not read bannedDependencyResources when flattening BOM with -Dquickly

### DIFF
--- a/maven-plugin/src/main/java/org/l2x6/cq/maven/FlattenBomMojo.java
+++ b/maven-plugin/src/main/java/org/l2x6/cq/maven/FlattenBomMojo.java
@@ -387,7 +387,7 @@ public class FlattenBomMojo extends AbstractMojo {
         }
 
         final Builder bannedDeps = GavSet.unionBuilder().defaultResult(GavSet.excludeAll());
-        if (bannedDependencyResources != null) {
+        if (bannedDependencyResources != null && !quickly) {
             bannedDependencyResources.stream()
                     .map(resource -> resource.getBannedSet(charset))
                     .forEach(bannedDeps::union);


### PR DESCRIPTION
fix https://github.com/apache/camel-quarkus/issues/7371