### PR TITLE
Support explicit per-attribute override of support levels in product source JSON

### DIFF
--- a/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/PlatformOverridesMojo.java
+++ b/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/PlatformOverridesMojo.java
@@ -25,10 +25,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -138,8 +138,18 @@ public class PlatformOverridesMojo extends AbstractMojo {
         List<Map<String, Object>> extensions = new ArrayList<>();
         model.put("extensions", extensions);
         for (Extension ext : product.getProductExtensions().values()) {
-            final String redhatSupportLevel = ext.redhatSupportLevel();
-            if (redhatSupportLevel != null) {
+            // Collect support levels for each configured attribute name
+            final Map<String, List<String>> supportLevelsByAttribute = new LinkedHashMap<>();
+            boolean hasAnySupport = false;
+            for (String attributeName : product.getPlatformOverridesSupportAttributeNames()) {
+                List<String> levels = ext.getSupportLevel(attributeName);
+                if (!levels.isEmpty()) {
+                    supportLevelsByAttribute.put(attributeName, levels);
+                    hasAnySupport = true;
+                }
+            }
+
+            if (hasAnySupport) {
                 final Map<String, Object> extModel = new LinkedHashMap<>();
 
                 final Ga ga = ext.getGa();
@@ -147,15 +157,19 @@ public class PlatformOverridesMojo extends AbstractMojo {
                 extModel.put("artifact-id", ga.getArtifactId());
 
                 final Map<String, Object> md = new LinkedHashMap<>();
-                for (String key : product.getPlatformOverridesSupportAttributeNames()) {
-                    md.put(key, Arrays.asList(redhatSupportLevel));
+                // Put each attribute's specific support levels
+                for (Entry<String, List<String>> entry : supportLevelsByAttribute.entrySet()) {
+                    md.put(entry.getKey(), entry.getValue());
                 }
 
                 if (overrideGuide) {
                     md.put("guide", product.getExtensionDocPageUrl(ga));
                 }
 
-                if (redhatSupportLevel.equals("supported-in-jvm")) {
+                // Check if any attribute contains "supported-in-jvm"
+                boolean hasSupportedInJvm = supportLevelsByAttribute.values().stream()
+                        .anyMatch(levels -> levels.contains("supported-in-jvm"));
+                if (hasSupportedInJvm) {
                     md.put("unlisted", "false");
                 }
 

--- a/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/Product.java
+++ b/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/Product.java
@@ -56,6 +56,14 @@ public class Product {
             final Map<String, Object> json = new Gson().fromJson(r, Map.class);
             final String groupId = (String) json.getOrDefault("groupId", "org.apache.camel.quarkus");
             final String prodGuideUrlTemplate = (String) json.get("guideUrlTemplate");
+
+            // Read platformOverridesSupportAttributeNames first, as it's needed when processing extensions
+            final Set<String> platformOverridesSupportAttributeNames = new LinkedHashSet<>();
+            Optional.ofNullable((String) json.get("platformOverridesSupportAttributeName"))
+                    .ifPresent(platformOverridesSupportAttributeNames::add);
+            ((List<String>) json.getOrDefault("platformOverridesSupportAttributeNames", new ArrayList<>()))
+                    .forEach(platformOverridesSupportAttributeNames::add);
+
             @SuppressWarnings("unchecked")
             final Map<String, Object> extensions = (Map<String, Object>) json.get("extensions");
             final Map<Ga, Product.Extension> extensionsMap = new TreeMap<>();
@@ -66,9 +74,21 @@ public class Product {
                 final String artifactId = en.getKey();
                 final Ga extensionGa = new Ga(groupId, artifactId);
                 Map<String, Object> extensionEntry = (Map<String, Object>) en.getValue();
+
+                // Collect overrides for all configured support attribute names
+                Map<String, List<String>> overrideSupportLevels = new LinkedHashMap<>();
+                for (String attrName : platformOverridesSupportAttributeNames) {
+                    @SuppressWarnings("unchecked")
+                    List<String> override = (List<String>) extensionEntry.get(attrName);
+                    if (override != null && !override.isEmpty()) {
+                        overrideSupportLevels.put(attrName, override);
+                    }
+                }
+
                 extensionsMap.put(extensionGa,
                         new Extension(extensionGa, ModeSupportStatus.valueOf((String) extensionEntry.get("jvm")),
-                                ModeSupportStatus.valueOf((String) extensionEntry.get("native"))));
+                                ModeSupportStatus.valueOf((String) extensionEntry.get("native")),
+                                overrideSupportLevels.isEmpty() ? null : overrideSupportLevels));
 
                 @SuppressWarnings("unchecked")
                 final List<String> allowedMixedTestsList = (List<String>) extensionEntry.get("allowedMixedTests");
@@ -159,12 +179,6 @@ public class Product {
                     .builder();
             ((List<String>) json.getOrDefault("ignoredTransitiveDependencies",
                     Collections.emptyList())).forEach(ignoredTransitiveDependencies::include);
-
-            final Set<String> platformOverridesSupportAttributeNames = new LinkedHashSet<>();
-            Optional.ofNullable((String) json.get("platformOverridesSupportAttributeName"))
-                    .ifPresent(platformOverridesSupportAttributeNames::add);
-            ((List<String>) json.getOrDefault("platformOverridesSupportAttributeNames", new ArrayList<>()))
-                    .forEach(platformOverridesSupportAttributeNames::add);
 
             return new Product(
                     Collections.unmodifiableMap(extensionsMap),
@@ -424,11 +438,18 @@ public class Product {
         private final Ga ga;
         private final ModeSupportStatus jvmSupportStatus;
         private final ModeSupportStatus nativeSupportStatus;
+        private final Map<String, List<String>> overrideSupportLevels;
 
         public Extension(Ga ga, ModeSupportStatus jvmSupportStatus, ModeSupportStatus nativeSupportStatus) {
+            this(ga, jvmSupportStatus, nativeSupportStatus, null);
+        }
+
+        public Extension(Ga ga, ModeSupportStatus jvmSupportStatus, ModeSupportStatus nativeSupportStatus,
+                Map<String, List<String>> overrideSupportLevels) {
             this.ga = ga;
             this.jvmSupportStatus = jvmSupportStatus;
             this.nativeSupportStatus = nativeSupportStatus;
+            this.overrideSupportLevels = overrideSupportLevels;
         }
 
         public boolean hasProductDocumentationPage() {
@@ -440,18 +461,50 @@ public class Product {
         }
 
         /**
-         * @return support level string usable Quarkus Platform metadata, such as
-         *         <code>"redhat-support" : [ "tech-preview" ]</code>
+         * Get support level for a specific attribute name.
+         *
+         * @param  attributeName the attribute name (e.g., "redhat-camel-support", "ibm-support")
+         * @return               support level strings for that attribute
          */
-        public String redhatSupportLevel() {
+        public List<String> getSupportLevel(String attributeName) {
+            // If an explicit override is provided for this attribute in the source JSON, use it directly
+            if (overrideSupportLevels != null && overrideSupportLevels.containsKey(attributeName)) {
+                return overrideSupportLevels.get(attributeName);
+            }
+
+            // Otherwise, derive from jvm/native statuses
+            return deriveSupportLevelFromStatus();
+        }
+
+        /**
+         * @return     support level strings usable in Quarkus Platform metadata, such as
+         *             <code>"redhat-support" : [ "tech-preview" ]</code> or
+         *             <code>"redhat-support" : [ "supported", "deprecated" ]</code>
+         * @deprecated Use {@link #getSupportLevel(String)} to get attribute-specific support levels
+         */
+        @Deprecated
+        public List<String> redhatSupportLevel() {
+            // Return the first override if any, otherwise derive from statuses
+            if (overrideSupportLevels != null && !overrideSupportLevels.isEmpty()) {
+                return overrideSupportLevels.values().iterator().next();
+            }
+            return deriveSupportLevelFromStatus();
+        }
+
+        private List<String> deriveSupportLevelFromStatus() {
             if (nativeSupportStatus == jvmSupportStatus) {
-                return nativeSupportStatus.quarkusSupportLevel;
+                // Both modes have the same status
+                if (nativeSupportStatus.quarkusSupportLevel == null) {
+                    return Collections.emptyList();
+                }
+                return Collections.singletonList(nativeSupportStatus.quarkusSupportLevel);
             }
             if (jvmSupportStatus == ModeSupportStatus.supported && nativeSupportStatus == ModeSupportStatus.techPreview) {
-                return "supported-in-jvm";
+                // Special case: supported in JVM, tech preview in native
+                return Collections.singletonList("supported-in-jvm");
             }
-            throw new IllegalStateException(
-                    "Cannot merge native support level " + nativeSupportStatus + " with JVM supportlevel " + jvmSupportStatus);
+            throw new IllegalStateException("Unexpected combination of jvm=" + jvmSupportStatus + " and native="
+                    + nativeSupportStatus + " for " + ga + ". Use explicit override in product source JSON.");
         }
 
     }

--- a/prod-maven-plugin/src/test/expected/platform-overrides/product/src/main/generated/camel-quarkus-product.json
+++ b/prod-maven-plugin/src/test/expected/platform-overrides/product/src/main/generated/camel-quarkus-product.json
@@ -1,0 +1,47 @@
+{
+  "extensions": [
+    {
+      "group-id": "org.apache.camel.quarkus",
+      "artifact-id": "camel-quarkus-avro",
+      "metadata": {
+        "redhat-support": [
+          "supported-in-jvm"
+        ],
+        "guide": "https://access.redhat.com/documentation/en-us/red_hat_integration/${cqMajorVersion}.latest/html/camel_extensions_for_quarkus_reference/extensions-avro",
+        "unlisted": "false"
+      }
+    },
+    {
+      "group-id": "org.apache.camel.quarkus",
+      "artifact-id": "camel-quarkus-bean",
+      "metadata": {
+        "redhat-support": [
+          "supported"
+        ],
+        "guide": "https://access.redhat.com/documentation/en-us/red_hat_integration/${cqMajorVersion}.latest/html/camel_extensions_for_quarkus_reference/extensions-bean"
+      }
+    },
+    {
+      "group-id": "org.apache.camel.quarkus",
+      "artifact-id": "camel-quarkus-direct",
+      "metadata": {
+        "redhat-support": [
+          "supported",
+          "deprecated"
+        ],
+        "guide": "https://access.redhat.com/documentation/en-us/red_hat_integration/${cqMajorVersion}.latest/html/camel_extensions_for_quarkus_reference/extensions-direct"
+      }
+    },
+    {
+      "group-id": "org.apache.camel.quarkus",
+      "artifact-id": "camel-quarkus-splunk",
+      "metadata": {
+        "redhat-support": [
+          "supported",
+          "deprecated"
+        ],
+        "guide": "https://access.redhat.com/documentation/en-us/red_hat_integration/${cqMajorVersion}.latest/html/camel_extensions_for_quarkus_reference/extensions-splunk"
+      }
+    }
+  ]
+}

--- a/prod-maven-plugin/src/test/expected/platform-overrides/product/src/main/resources/camel-quarkus-product-source.json
+++ b/prod-maven-plugin/src/test/expected/platform-overrides/product/src/main/resources/camel-quarkus-product-source.json
@@ -1,0 +1,52 @@
+{
+    "extensions": {
+        "camel-quarkus-bean": {
+            "jvm": "supported",
+            "native": "supported",
+            "comment": "both supported - should derive to single ['supported']"
+        },
+        "camel-quarkus-avro": {
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": "supported/techPreview - should derive to ['supported-in-jvm']"
+        },
+        "camel-quarkus-direct": {
+            "jvm": "supported",
+            "native": "deprecated",
+            "redhat-support": [
+                "supported",
+                "deprecated"
+            ],
+            "comment": "different statuses - requires explicit override"
+        },
+        "camel-quarkus-splunk": {
+            "jvm": "deprecated",
+            "native": "deprecated",
+            "redhat-support": [
+                "supported",
+                "deprecated"
+            ],
+            "comment": "explicit override - should use ['supported', 'deprecated'] not derived ['deprecated']"
+        },
+        "camel-quarkus-community": {
+            "jvm": "community",
+            "native": "community",
+            "comment": "community - should not appear in output (empty support levels)"
+        }
+    },
+    "excludeTests": [],
+    "additionalProductizedArtifacts": [
+        "camel-quarkus-catalog"
+    ],
+    "guideUrlTemplate": "https://access.redhat.com/documentation/en-us/red_hat_integration/${cqMajorVersion}.latest/html/camel_extensions_for_quarkus_reference/extensions-${artifactIdBase}",
+    "integrationTests": [
+        {
+            "basedir": ".",
+            "includes": [
+                "integration-tests/*/pom.xml"
+            ],
+            "excludes": []
+        }
+    ],
+    "platformOverridesSupportAttributeNames": ["redhat-support"]
+}

--- a/prod-maven-plugin/src/test/java/org/l2x6/cq/maven/prod/ProdExcludesMojoTest.java
+++ b/prod-maven-plugin/src/test/java/org/l2x6/cq/maven/prod/ProdExcludesMojoTest.java
@@ -81,4 +81,31 @@ public class ProdExcludesMojoTest {
         TestUtils.assertTreesMatch(Paths.get("src/test/expected/" + testName), mojo.basedir.toPath());
     }
 
+    @Test
+    void platformOverrides() throws MojoExecutionException, MojoFailureException, IOException {
+        final String testName = "platform-overrides-test";
+        final Path projectDir = TestUtils.createProjectFromTemplate("prod-excludes", testName);
+        final Path basePath = projectDir.toAbsolutePath().normalize();
+
+        final Path productJsonPath = basePath.resolve("product/src/main/resources/camel-quarkus-product-source.json");
+        try (InputStream in = getClass().getClassLoader()
+                .getResourceAsStream("camel-quarkus-product-source-platform-overrides.json")) {
+            Files.copy(in, productJsonPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        // Run platform-overrides mojo
+        final PlatformOverridesMojo platformMojo = new PlatformOverridesMojo();
+        platformMojo.basedir = basePath.toFile();
+        platformMojo.encoding = "utf-8";
+        platformMojo.documentedProductVersion = "3.8";
+        platformMojo.productJson = productJsonPath.toFile();
+        platformMojo.overrideGuide = true;
+        platformMojo.execute();
+
+        // Compare generated file with expected
+        final Path generatedDir = basePath.resolve("product/src/main/generated");
+        TestUtils.assertTreesMatch(Paths.get("src/test/expected/platform-overrides/product/src/main/generated"),
+                generatedDir);
+    }
+
 }

--- a/prod-maven-plugin/src/test/resources/camel-quarkus-product-source-platform-overrides.json
+++ b/prod-maven-plugin/src/test/resources/camel-quarkus-product-source-platform-overrides.json
@@ -1,0 +1,52 @@
+{
+    "extensions": {
+        "camel-quarkus-bean": {
+            "jvm": "supported",
+            "native": "supported",
+            "comment": "both supported - should derive to single ['supported']"
+        },
+        "camel-quarkus-avro": {
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": "supported/techPreview - should derive to ['supported-in-jvm']"
+        },
+        "camel-quarkus-direct": {
+            "jvm": "supported",
+            "native": "deprecated",
+            "redhat-support": [
+                "supported",
+                "deprecated"
+            ],
+            "comment": "different statuses - requires explicit override"
+        },
+        "camel-quarkus-splunk": {
+            "jvm": "deprecated",
+            "native": "deprecated",
+            "redhat-support": [
+                "supported",
+                "deprecated"
+            ],
+            "comment": "explicit override - should use ['supported', 'deprecated'] not derived ['deprecated']"
+        },
+        "camel-quarkus-community": {
+            "jvm": "community",
+            "native": "community",
+            "comment": "community - should not appear in output (empty support levels)"
+        }
+    },
+    "excludeTests": [],
+    "additionalProductizedArtifacts": [
+        "camel-quarkus-catalog"
+    ],
+    "guideUrlTemplate": "https://access.redhat.com/documentation/en-us/red_hat_integration/${cqMajorVersion}.latest/html/camel_extensions_for_quarkus_reference/extensions-${artifactIdBase}",
+    "integrationTests": [
+        {
+            "basedir": ".",
+            "includes": [
+                "integration-tests/*/pom.xml"
+            ],
+            "excludes": []
+        }
+    ],
+    "platformOverridesSupportAttributeNames": ["redhat-support"]
+}


### PR DESCRIPTION
Added support for explicit per-attribute overrides in product source JSON files. Extensions can now specify arrays like `"redhat-camel-support": ["supported", "deprecated"]` or `"ibm-support": ["supported", "deprecated"]` which take precedence over derived values from jvm/native statuses.

Extensions can now specify explicit override arrays in product source JSON:
```
  "camel-quarkus-splunk": {
      "jvm": "deprecated", 
      "native": "deprecated", 
      "redhat-camel-support": ["supported", "deprecated"]
  }
```

Detail:
* Extension.getSupportLevel(attributeName) returns override if present, otherwise derives from jvm/native                                                                                        
* Support for multiple platformOverridesSupportAttributeNames with different override values per attribute                                                                                       
* Added comprehensive test covering override and derivation scenario