### PR TITLE
 Support artifact-specific version overrides in TransitiveDependencies

### DIFF
--- a/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/Product.java
+++ b/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/Product.java
@@ -180,6 +180,10 @@ public class Product {
             ((List<String>) json.getOrDefault("ignoredTransitiveDependencies",
                     Collections.emptyList())).forEach(ignoredTransitiveDependencies::include);
 
+            @SuppressWarnings("unchecked")
+            final Map<String, String> artifactVersionOverrides = (Map<String, String>) json
+                    .getOrDefault("artifactVersionOverrides", Collections.emptyMap());
+
             return new Product(
                     Collections.unmodifiableMap(extensionsMap),
                     groupId,
@@ -203,7 +207,8 @@ public class Product {
                     bannedDeps.build(),
                     Collections.unmodifiableMap(transitiveDependencyReplacements),
                     ignoredTransitiveDependencies.build(),
-                    platformOverridesSupportAttributeNames);
+                    platformOverridesSupportAttributeNames,
+                    Collections.unmodifiableMap(artifactVersionOverrides));
         } catch (Exception e) {
             throw new RuntimeException("Could not read " + absProdJson, e);
         }
@@ -245,6 +250,15 @@ public class Product {
      * @since       4.18.0
      */
     private final Set<String> platformOverridesSupportAttributeNames;
+    /**
+     * Artifact-specific version property mappings.
+     * Maps from artifactId to the version property expression that should be used.
+     * This allows specific artifacts to use custom version properties instead of the default edition-based versions.
+     * For example: {"camel-launcher": "${camel.launcher.version}"}
+     *
+     * @since 4.24.0
+     */
+    private final Map<String, String> artifactVersionOverrides;
 
     public Product(
             Map<Ga, Product.Extension> extensions,
@@ -266,7 +280,8 @@ public class Product {
             GavSet bannedDependencies,
             Map<Ga, Ga> transitiveDependencyReplacements,
             GavSet ignoredTransitiveDependencies,
-            Set<String> platformOverridesSupportAttributeNames) {
+            Set<String> platformOverridesSupportAttributeNames,
+            Map<String, String> artifactVersionOverrides) {
         this.extensions = extensions;
         this.groupId = groupId;
         this.prodGuideUrlTemplate = prodGuideUrlTemplate;
@@ -294,6 +309,8 @@ public class Product {
         if (platformOverridesSupportAttributeNames.isEmpty()) {
             throw new IllegalArgumentException("platformOverridesSupportAttributeName must be set");
         }
+        this.artifactVersionOverrides = Objects.requireNonNull(artifactVersionOverrides,
+                "artifactVersionOverrides must not be null");
     }
 
     /**
@@ -429,6 +446,10 @@ public class Product {
 
     public Set<String> getPlatformOverridesSupportAttributeNames() {
         return platformOverridesSupportAttributeNames;
+    }
+
+    public Map<String, String> getArtifactVersionOverrides() {
+        return artifactVersionOverrides;
     }
 
     /**

--- a/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/TransitiveDependenciesMojo.java
+++ b/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/TransitiveDependenciesMojo.java
@@ -80,16 +80,6 @@ import org.w3c.dom.Document;
 public class TransitiveDependenciesMojo {
 
     /**
-     * Artifact-specific version property mappings.
-     * Maps from artifactId to the version property that should be used.
-     * This allows specific artifacts to use custom version properties instead of the default edition-based versions.
-     */
-    private static final Map<String, String> ARTIFACT_VERSION_OVERRIDES = new HashMap<>();
-    static {
-        ARTIFACT_VERSION_OVERRIDES.put("camel-launcher", "${camel.launcher.version}");
-    }
-
-    /**
      * The version of the current source tree
      *
      * @since 2.17.0
@@ -386,8 +376,11 @@ public class TransitiveDependenciesMojo {
                             .filter(gavtcs -> gavtcs.getGroupId().equals("org.apache.camel"))
                             .forEach(gavtcs -> {
                                 final Ga ga = new Ga(gavtcs.getGroupId(), gavtcs.getArtifactId());
-                                // Check for artifact-specific version override first
-                                final String expectedVersion = ARTIFACT_VERSION_OVERRIDES.getOrDefault(
+                                // Check for artifact-specific version override from product JSON first
+                                final Map<String, String> overrides = product != null
+                                        ? product.getArtifactVersionOverrides()
+                                        : Collections.emptyMap();
+                                final String expectedVersion = overrides.getOrDefault(
                                         gavtcs.getArtifactId(),
                                         prodCamelGas.contains(ga)
                                                 ? CamelEdition.PRODUCT.getVersionExpression()

--- a/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/TransitiveDependenciesMojo.java
+++ b/prod-maven-plugin/src/main/java/org/l2x6/cq/maven/prod/TransitiveDependenciesMojo.java
@@ -80,6 +80,16 @@ import org.w3c.dom.Document;
 public class TransitiveDependenciesMojo {
 
     /**
+     * Artifact-specific version property mappings.
+     * Maps from artifactId to the version property that should be used.
+     * This allows specific artifacts to use custom version properties instead of the default edition-based versions.
+     */
+    private static final Map<String, String> ARTIFACT_VERSION_OVERRIDES = new HashMap<>();
+    static {
+        ARTIFACT_VERSION_OVERRIDES.put("camel-launcher", "${camel.launcher.version}");
+    }
+
+    /**
      * The version of the current source tree
      *
      * @since 2.17.0
@@ -376,9 +386,12 @@ public class TransitiveDependenciesMojo {
                             .filter(gavtcs -> gavtcs.getGroupId().equals("org.apache.camel"))
                             .forEach(gavtcs -> {
                                 final Ga ga = new Ga(gavtcs.getGroupId(), gavtcs.getArtifactId());
-                                final String expectedVersion = prodCamelGas.contains(ga)
-                                        ? CamelEdition.PRODUCT.getVersionExpression()
-                                        : CamelEdition.COMMUNITY.getVersionExpression();
+                                // Check for artifact-specific version override first
+                                final String expectedVersion = ARTIFACT_VERSION_OVERRIDES.getOrDefault(
+                                        gavtcs.getArtifactId(),
+                                        prodCamelGas.contains(ga)
+                                                ? CamelEdition.PRODUCT.getVersionExpression()
+                                                : CamelEdition.COMMUNITY.getVersionExpression());
                                 if (!expectedVersion.equals(gavtcs.getVersion())) {
                                     gavtcs.getNode().setVersion(expectedVersion);
                                 }

--- a/prod-maven-plugin/src/test/resources/camel-quarkus-product-source-platform-overrides.json
+++ b/prod-maven-plugin/src/test/resources/camel-quarkus-product-source-platform-overrides.json
@@ -48,5 +48,8 @@
             "excludes": []
         }
     ],
-    "platformOverridesSupportAttributeNames": ["redhat-support"]
+    "platformOverridesSupportAttributeNames": ["redhat-support"],
+    "artifactVersionOverrides": {
+        "camel-launcher": "${camel.launcher.version}"
+    }
 }


### PR DESCRIPTION
Enhances the prod-maven-plugin with the following capabilities:                                                                                                        
  - Support for configuring multiple products in platform overrides
  - Artifact-specific version overrides in TransitiveDependenciesMojo