### PR TITLE
Use consistent commons-io version throughout plugins

### DIFF
--- a/camel-prod-maven-plugin/pom.xml
+++ b/camel-prod-maven-plugin/pom.xml
@@ -104,7 +104,7 @@
                     <dependency>
                         <groupId>commons-io</groupId>
                         <artifactId>commons-io</artifactId>
-                        <version>2.21.0</version>
+                        <version>${commons-io.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/camel-prod-maven-plugin/pom.xml
+++ b/camel-prod-maven-plugin/pom.xml
@@ -53,6 +53,11 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <scope>provided</scope>

--- a/camel-prod-maven-plugin/pom.xml
+++ b/camel-prod-maven-plugin/pom.xml
@@ -53,11 +53,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <scope>provided</scope>
@@ -99,5 +94,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
+                        <version>2.21.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/camel-spring-boot-prod-maven-plugin/pom.xml
+++ b/camel-spring-boot-prod-maven-plugin/pom.xml
@@ -48,11 +48,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <scope>provided</scope>
@@ -92,5 +87,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
+                        <version>2.21.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/camel-spring-boot-prod-maven-plugin/pom.xml
+++ b/camel-spring-boot-prod-maven-plugin/pom.xml
@@ -97,7 +97,7 @@
                     <dependency>
                         <groupId>commons-io</groupId>
                         <artifactId>commons-io</artifactId>
-                        <version>2.21.0</version>
+                        <version>${commons-io.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/camel-spring-boot-prod-maven-plugin/pom.xml
+++ b/camel-spring-boot-prod-maven-plugin/pom.xml
@@ -48,6 +48,11 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,6 @@
         <quarkus.version>3.33.1.1</quarkus.version>
 
         <camel.version>4.18.2</camel.version>
-        <commons-io.version>2.21.0</commons-io.version>
         <freemarker.version>2.3.34</freemarker.version>
         <assertj.version>3.27.7</assertj.version>
 
@@ -222,12 +221,6 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${commons-io.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <quarkus.version>3.33.1.1</quarkus.version>
 
         <camel.version>4.18.2</camel.version>
+        <commons-io.version>2.21.0</commons-io.version>
         <freemarker.version>2.3.34</freemarker.version>
         <assertj.version>3.27.7</assertj.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <quarkus.version>3.33.1.1</quarkus.version>
 
         <camel.version>4.18.2</camel.version>
+        <commons-io.version>2.21.0</commons-io.version>
         <freemarker.version>2.3.34</freemarker.version>
         <assertj.version>3.27.7</assertj.version>
 
@@ -221,6 +222,12 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
             </dependency>
 
             <dependency>

--- a/prod-maven-plugin/pom.xml
+++ b/prod-maven-plugin/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.21.0</version>
+            <version>${commons-io.version}</version>
         </dependency>
 
         <dependency>
@@ -150,7 +150,7 @@
                     <dependency>
                         <groupId>commons-io</groupId>
                         <artifactId>commons-io</artifactId>
-                        <version>2.21.0</version>
+                        <version>${commons-io.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/prod-maven-plugin/pom.xml
+++ b/prod-maven-plugin/pom.xml
@@ -67,6 +67,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+            <version>2.21.0</version>
         </dependency>
 
         <dependency>
@@ -139,5 +140,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
+                        <version>2.21.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/prod-maven-plugin/pom.xml
+++ b/prod-maven-plugin/pom.xml
@@ -65,6 +65,11 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
         </dependency>


### PR DESCRIPTION
https://github.com/l2x6/cq-maven-plugin/issues/868

Was getting a compile error it looks like because of commons-io version incompatibility.      Use a consistent version throughout.